### PR TITLE
Added proper support of subrequests

### DIFF
--- a/DependencyInjection/KnplabsPaginatorExtension.php
+++ b/DependencyInjection/KnplabsPaginatorExtension.php
@@ -30,13 +30,12 @@ class KnplabsPaginatorExtension extends Extension
             $helperDefinition = new Definition('%knplabs_paginator.templating.helper.class%');
             $helperDefinition
                 ->addTag('templating.helper', array('alias' => 'pagination'))
+                ->addTag('kernel.listener', array('event' => 'core.request', 'method' => 'onCoreRequest'))
                 ->addMethodCall('setTemplate', array($config['templating']['template']))
                 ->addMethodCall('setStyle', array($config['templating']['style']))
-                ->setScope('request')
                 ->setArguments(array(
                     new Reference('templating'),
                     new Reference('templating.helper.router'),
-                    new Reference('request'),
                     new Reference('translator'),
                 ));
             $container->setDefinition('templating.helper.knplabs_paginator', $helperDefinition);

--- a/Templating/PaginatorExtension.php
+++ b/Templating/PaginatorExtension.php
@@ -50,11 +50,12 @@ class PaginatorExtension extends \Twig_Extension
      * @param string $key
      * @param array $options
      * @param array $params
+     * @param string $route
      * @return string
      */
-    public function sortable(Paginator $paginator, $title, $key, $options = array(), $params = array())
+    public function sortable(Paginator $paginator, $title, $key, $options = array(), $params = array(), $route = null)
     {
-        return $this->container->get('templating.helper.knplabs_paginator')->sortable($paginator, $title, $key, $options, $params);
+        return $this->container->get('templating.helper.knplabs_paginator')->sortable($paginator, $title, $key, $options, $params, $route);
     }
 
     /**
@@ -66,11 +67,12 @@ class PaginatorExtension extends \Twig_Extension
      * @param string $template
      * @param array $custom - custom parameters
      * @param array $routeparams - params for the route
+     * @param string $route
      * @return string
      */
-    public function paginate(Paginator $paginator, $template = null, $custom = array(), $routeparams = array())
+    public function paginate(Paginator $paginator, $template = null, $custom = array(), $routeparams = array(), $route = null)
     {
-        return $this->container->get('templating.helper.knplabs_paginator')->paginate($paginator, $template, $custom, $routeparams);
+        return $this->container->get('templating.helper.knplabs_paginator')->paginate($paginator, $template, $custom, $routeparams, $route);
     }
 
     /**


### PR DESCRIPTION
The helper now uses the `core.request` event to get the request from the master request (and it is not of the request scope anymore, which would have broken the PHPEngine if I'm right). This allow subrequests to use the good route.
The method also allow to set the route explicitly which is needed for ESI requests (where there is no way to guess the route to use). The remaining issue for ESI requests is that query parameters of the request are merged with the passed parameters, which adds unnecessary params in this case. A solution could be to merge the parameters of the request object only when the route is not supplied explicitly.
