### PR TITLE
Fix the call of class 'Twig_Filter_Method'

### DIFF
--- a/Templating/PaginatorExtension.php
+++ b/Templating/PaginatorExtension.php
@@ -33,7 +33,7 @@ class PaginatorExtension extends \Twig_Extension
     {
         return array(
             'sortable' => new \Twig_Filter_Method($this, 'sortable', array('is_safe' => array('html'))),
-            'paginate' => new \Twig_Filter_method($this, 'paginate', array('is_safe' => array('html')))
+            'paginate' => new \Twig_Filter_Method($this, 'paginate', array('is_safe' => array('html')))
         );
     }
 


### PR DESCRIPTION
Just correct the lowercase of caracter to uppercase (when call the constructor of Twig_Filter_Method class)
