### PR TITLE
Fix build attributes of the sortable link

### DIFF
--- a/Resources/views/Pagination/sortable_link.html.twig
+++ b/Resources/views/Pagination/sortable_link.html.twig
@@ -1,6 +1,6 @@
 {% set link = "" %}
 {% for attr, value in options %}
-    {% set link = link ~ " " ~ attr ~ "=" ~ value %}
+    {% set link = link ~ " " ~ attr ~ '="' ~ value|e ~'"' %}
 {% endfor %}
 
-<a {{ link }}>{{ title }}</a>
+<a {{ link|raw }}>{{ title }}</a>


### PR DESCRIPTION
When I use sortable link:
    {{ paginator|sortable('User name', 'a.usernameCanonical') }}

the result was a

```
    <a href=http://... title=User name>User name</a>
```

I added quotes
