### PR TITLE
Fixed setting of priority of event lsiteners

### DIFF
--- a/DependencyInjection/Compiler/PaginatorConfigurationPass.php
+++ b/DependencyInjection/Compiler/PaginatorConfigurationPass.php
@@ -22,13 +22,12 @@ class PaginatorConfigurationPass implements CompilerPassInterface
         $definition = $container->getDefinition('knp_paginator.adapter');
 
         foreach ($container->findTaggedServiceIds('knp_paginator.listener.orm') as $id => $attributes) {
-            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
-            $definition->addMethodCall('addListenerService', array($id, 'orm', $priority));
+            $definition->addMethodCall('addListenerService', array($id, 'orm'));
         }
 
         foreach ($container->findTaggedServiceIds('knp_paginator.listener.odm') as $id => $attributes) {
-            $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
-            $definition->addMethodCall('addListenerService', array($id, 'odm', $priority));
+            $definition->addMethodCall('addListenerService', array($id, 'odm'));
         }
+
     }
 }

--- a/Event/Listener/ODM/Paginate.php
+++ b/Event/Listener/ODM/Paginate.php
@@ -61,8 +61,8 @@ class Paginate implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            CountEvent::NAME => 'count',
-            ItemsEvent::NAME => 'items'
+            ItemsEvent::NAME => array('items', 0),
+            CountEvent::NAME => array('count', 0)
         );
     }
 }

--- a/Event/Listener/ODM/Sortable.php
+++ b/Event/Listener/ODM/Sortable.php
@@ -61,7 +61,7 @@ class Sortable implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            ItemsEvent::NAME => 'items'
+            ItemsEvent::NAME => array('items', 128)
         );
     }
 }

--- a/Event/Listener/ORM/Paginate.php
+++ b/Event/Listener/ORM/Paginate.php
@@ -98,8 +98,8 @@ class Paginate implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            ItemsEvent::NAME => 'items',
-            CountEvent::NAME => 'count'
+            ItemsEvent::NAME => array('items', 0),
+            CountEvent::NAME => array('count', 0)
         );
     }
 }

--- a/Event/Listener/ORM/Sortable.php
+++ b/Event/Listener/ORM/Sortable.php
@@ -83,7 +83,7 @@ class Sortable implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            ItemsEvent::NAME => 'items'
+            ItemsEvent::NAME => array('items', 128)
         );
     }
 }

--- a/Paginator/Adapter.php
+++ b/Paginator/Adapter.php
@@ -38,7 +38,6 @@ interface Adapter extends ZendPaginatorAdapter
      *
      * @param string $serviceId
      * @param string $type
-     * @param string $priority
      */
-    public function addListenerService($serviceId, $type, $priority);
+    public function addListenerService($serviceId, $type);
 }

--- a/Paginator/Adapter/Doctrine.php
+++ b/Paginator/Adapter/Doctrine.php
@@ -161,7 +161,7 @@ class Doctrine implements Adapter
         if ($this->usedType != $type) {
             $this->eventDispatcher = new EventDispatcher();
             foreach ($this->listenerServices[$type] as $options) {
-                $this->eventDispatcher->addSubscriber($this->container->get($options['service']), $options['priority']);
+                $this->eventDispatcher->addSubscriber($this->container->get($options['service']));
             }
             $this->usedType = $type;
         }
@@ -238,9 +238,9 @@ class Doctrine implements Adapter
     /**
      * {@inheritdoc}
      */
-    public function addListenerService($serviceId, $type, $priority)
+    public function addListenerService($serviceId, $type)
     {
-        $this->listenerServices[$type][] = array('service' => $serviceId, 'priority' => $priority);
+        $this->listenerServices[$type][] = array('service' => $serviceId);
     }
 
     /**

--- a/Resources/config/paginator.xml
+++ b/Resources/config/paginator.xml
@@ -20,19 +20,19 @@
         </service>
 
         <service id="knp_paginator.event.listener.orm.sortable" class="%knp_paginator.event.listener.orm.sortable.class%" scope="request">
-            <tag name="knp_paginator.listener.orm" priority="128" />
+            <tag name="knp_paginator.listener.orm" />
             <argument type="service" id="request" />
         </service>
         <service id="knp_paginator.event.listener.orm.paginate" class="%knp_paginator.event.listener.orm.paginate.class%" scope="request">
-            <tag name="knp_paginator.listener.orm" priority="0" />
+            <tag name="knp_paginator.listener.orm" />
         </service>
 
         <service id="knp_paginator.event.listener.odm.sortable" class="%knp_paginator.event.listener.odm.sortable.class%" scope="request">
-            <tag name="knp_paginator.listener.odm" priority="128" />
+            <tag name="knp_paginator.listener.odm" />
             <argument type="service" id="request" />
         </service>
         <service id="knp_paginator.event.listener.odm.paginate" class="%knp_paginator.event.listener.odm.paginate.class%" scope="request">
-            <tag name="knp_paginator.listener.odm" priority="0" />
+            <tag name="knp_paginator.listener.odm" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
The priority is not passed when registering events as subscribers instead of listeners. It is retrieved from the options in the getSubscribedEvents method instead. The priority of the listeners was being ignored but the order they appeared in the paginator.xml file meant they worked as expected.
