### PR TITLE
passing key to sortable_link template

### DIFF
--- a/Pagination/SlidingPagination.php
+++ b/Pagination/SlidingPagination.php
@@ -140,7 +140,7 @@ class SlidingPagination extends AbstractPagination
             $this->sortableTemplate = $template;
         }
 
-        return $this->engine->render($this->sortableTemplate, compact('options', 'title', 'direction', 'sorted'));
+        return $this->engine->render($this->sortableTemplate, compact('options', 'title', 'direction', 'sorted', 'key'));
     }
 
     public function getPaginationData()


### PR DESCRIPTION
The key is sometimes needed in the template. For example, if you want to replace &lt;a&gt; tags with form submit buttons.

for example: (# in my custom template -> button_sortable_link.html.twig)

&lt;button name="sort" type="submit" title="{{ title }}" value="{{ key }}"&gt;

then in the controller:

if($request->request->has('sort'))
// return template with data sorted by $key = $request->request->get('sort')

Example of usage:

I have a Create UserGroup form with $roles array (which is a collection of Roles).
Below standard field like UserGroup name or UserGroup description I have a list of Roles which is Paginated.

If I click &lt;a&gt; link to browse roles list to another page - I loose my input. So I chose to replace it with submit buttons - this way my input is submitted and re-entered into response.
