### PR TITLE
passing $alias to sortable template

### DIFF
--- a/Pagination/SlidingPagination.php
+++ b/Pagination/SlidingPagination.php
@@ -139,8 +139,10 @@ class SlidingPagination extends AbstractPagination
         if ($template) {
             $this->sortableTemplate = $template;
         }
+        
+        $alias = $this->alias;
 
-        return $this->engine->render($this->sortableTemplate, compact('options', 'title', 'direction', 'sorted', 'key'));
+        return $this->engine->render($this->sortableTemplate, compact('options', 'title', 'direction', 'sorted', 'key', 'alias'));
     }
 
     public function getPaginationData()


### PR DESCRIPTION
Needed if you want to create custom sortable buttons and you are useing multiple paginators.

In my case:
- I had a FORM createUser
- within that form I had two lists: roles list and groups list
- both of them paginated by KnpPaginator
- to submit user inputed data when sorting the lists I had to replace Anchor tags with Button tags
- to distinguish in the controller which paginator (which list) sent the sorting request I had to set paginator's alias as submit buttons name
- in order to render submit button with paginator's alias as its name I had to make this small change :)
