### PR TITLE
Support Symfony2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "2.*,<2.2",
+        "symfony/framework-bundle": "2.*,<2.3",
         "knplabs/knp-components": ">=1.1",
         "twig/twig": ">=1.5"
     },


### PR DESCRIPTION
Since tagging has moved and symfony standard edition dev-master is 2.2, you can no longer install the knppaginatorbundle.  Everything is tested and working fine so should that restriction be there anymore?
