### PR TITLE
Added PaginatorAwarePass CompilerPass.

### DIFF
--- a/Definition/PaginatorAware.php
+++ b/Definition/PaginatorAware.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Knp\Bundle\PaginatorBundle\Definition;
+
+use Knp\Bundle\PaginatorBundle\Definition\PaginatorAwareInterface;
+use Knp\Component\Pager\Paginator;
+
+/**
+ * Class PaginatorAware
+ *
+ * This is a base class that can be extended if you're too lazy to implement PaginatorAwareInterface yourself.
+ */
+class PaginatorAware implements PaginatorAwareInterface
+{
+    /**
+     * @var Paginator
+     */
+    private $paginator;
+
+    /**
+     * Sets the KnpPaginator instance.
+     *
+     * @param Paginator $paginator
+     *
+     * @return PaginatorAware
+     */
+    public function setPaginator(Paginator $paginator)
+    {
+        $this->paginator = $paginator;
+
+        return $this;
+    }
+
+    /**
+     * Returns the KnpPaginator instance.
+     *
+     * @return Paginator
+     */
+    public function getPaginator()
+    {
+        return $this->paginator;
+    }
+}

--- a/Definition/PaginatorAwareInterface.php
+++ b/Definition/PaginatorAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Knp\Bundle\PaginatorBundle\Definition;
+
+use Knp\Component\Pager\Paginator;
+
+/**
+ * Interface PaginatorAwareInterface
+ *
+ * PaginatorAwareInterface should be implemented by classes that depend on a KnpPaginator service.
+ */
+interface PaginatorAwareInterface
+{
+    /**
+     * Sets the KnpPaginator instance.
+     *
+     * @param Paginator $paginator
+     *
+     * @return mixed
+     */
+    public function setPaginator(Paginator $paginator);
+}

--- a/DependencyInjection/Compiler/PaginatorAwarePass.php
+++ b/DependencyInjection/Compiler/PaginatorAwarePass.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Knp\Bundle\PaginatorBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class PaginatorAwarePass
+ *
+ * This compiler scans for the 'knp_paginator.injectable' tag and injects the Paginator service.
+ */
+class PaginatorAwarePass implements CompilerPassInterface
+{
+    /**
+     * @var string
+     */
+    const PAGINATOR_AWARE_TAG = 'knp_paginator.injectable';
+
+    /**
+     * @var string
+     */
+    const PAGINATOR_AWARE_INTERFACE = 'Knp\Bundle\PaginatorBundle\Definition\PaginatorAwareInterface';
+
+    /**
+     * Populates all tagged services with the paginator service
+     *
+     * @param ContainerBuilder $container
+     *
+     * @throws \InvalidArgumentException
+     * @throws \Symfony\Component\Config\Definition\Exception\InvalidDefinitionException
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $defaultAttributes = array('paginator' => 'knp_paginator');
+
+        foreach ($container->findTaggedServiceIds(self::PAGINATOR_AWARE_TAG) as $id => $attributes) {
+            $definition = $container->getDefinition($id);
+
+            $refClass = new \ReflectionClass($definition->getClass());
+            if (!$refClass->implementsInterface(self::PAGINATOR_AWARE_INTERFACE)) {
+                throw new \InvalidArgumentException(
+                    sprintf('Service "%s" must implement interface "%s".', $id, self::PAGINATOR_AWARE_INTERFACE)
+                );
+            }
+
+            $attributes = array_merge($defaultAttributes, $attributes);
+            if (!$container->has($attributes['paginator'])) {
+                throw new InvalidDefinitionException(
+                    sprintf(
+                        'Paginator service "%s" for tag "%s" on service "%s" could not be found.',
+                        $attributes['paginator'],
+                        self::PAGINATOR_AWARE_TAG,
+                        $id
+                    )
+                );
+            }
+
+            $definition->addMethodCall('setPaginator', array(new Reference($attributes['paginator'])));
+            $container->setDefinition($id, $definition);
+        }
+    }
+}

--- a/KnpPaginatorBundle.php
+++ b/KnpPaginatorBundle.php
@@ -9,9 +9,10 @@
 
 namespace Knp\Bundle\PaginatorBundle;
 
+use Knp\Bundle\PaginatorBundle\DependencyInjection\Compiler\PaginatorAwarePass;
+use Knp\Bundle\PaginatorBundle\DependencyInjection\Compiler\PaginatorConfigurationPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Knp\Bundle\PaginatorBundle\DependencyInjection\Compiler\PaginatorConfigurationPass;
 
 class KnpPaginatorBundle extends Bundle
 {
@@ -22,5 +23,6 @@ class KnpPaginatorBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new PaginatorConfigurationPass());
+        $container->addCompilerPass(new PaginatorAwarePass());
     }
 }

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Currently paginator can paginate:
 ```php
 // Acme\MainBundle\Controller\ArticleController.php
 
-public function listAction() 
+public function listAction()
 {
     $em    = $this->get('doctrine.orm.entity_manager');
     $dql   = "SELECT a FROM AcmeMainBundle:Article a";
@@ -198,6 +198,35 @@ translationCount and translationParameters can be combined.
 </table>
 ```
 
+### Dependency Injection
+
+You can automatically inject a paginator service into another service by using the ```knp_paginator.injectable``` DIC tag.
+The tag takes one optional argument ```paginator```, which is the ID of the paginator service that should be injected.
+It defaults to ```knp_paginator```.
+
+The class that receives the KnpPaginator service must implement ```Knp\Bundle\PaginatorBundle\Definition\PaginatorAwareInterface```.
+If you're too lazy you can also just extend the ```Knp\Bundle\PaginatorBundle\Definition\PaginatorAware``` base class.
+
+###### XML configuration example
+
+```xml
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="my_bundle.paginator_aware.class">MyBundle\Repository\PaginatorAwareRepository</parameter>
+    </parameters>
+
+    <services>
+        <service id="my_bundle.paginator_aware" class="my_bundle.paginator_aware.class">
+            <tag name="knp_paginator.injectable" paginator="knp_paginator" />
+        </service>
+    </services>
+</container>
+```
 
 [knp_component_pager]: https://github.com/KnpLabs/knp-components/blob/master/doc/pager/intro.md "Knp Pager component introduction"
 [doc_custom_pagination_subscriber]: https://github.com/KnpLabs/KnpPaginatorBundle/tree/master/Resources/doc/custom_pagination_subscribers.md "Custom pagination subscribers"

--- a/Tests/DependencyInjection/Compiler/PaginatorAwarePassTest.php
+++ b/Tests/DependencyInjection/Compiler/PaginatorAwarePassTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Knp\Bundle\PaginatorBundle\Tests\DependencyInjection\Compiler;
+
+use Knp\Bundle\PaginatorBundle\DependencyInjection\Compiler\PaginatorAwarePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Class PaginatorAwarePassTest
+ */
+class PaginatorAwarePassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    public $container;
+
+    /**
+     * @var PaginatorAwarePass
+     */
+    public $pass;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $this->pass      = new PaginatorAwarePass();
+    }
+
+    public function testCorrectPassProcess()
+    {
+        $tagged = array(
+            'tag.one' => array('paginator' => 'knp.paginator')
+        );
+
+        $classes = array(
+            'tag.one' => 'Knp\Bundle\PaginatorBundle\Definition\PaginatorAware'
+        );
+
+        $definition = $this->setUpContainerMock('tag.one', $tagged, $classes);
+
+        $tested = clone $definition;
+        $tested->addMethodCall('setPaginator', array(new Reference('knp.paginator')));
+
+        $this->container
+            ->expects($this->once())
+            ->method('setDefinition')
+            ->with('tag.one', $tested)
+        ;
+
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Service "tag.one" must implement interface "Knp\Bundle\PaginatorBundle\Definition\PaginatorAwareInterface".
+     */
+    public function testExceptionWrongInterface()
+    {
+        $tagged = array(
+            'tag.one' => array('paginator' => 'knp.paginator')
+        );
+
+        $classes = array(
+            'tag.one' => 'Knp\Bundle\PaginatorBundle\Helper\Processor'
+        );
+
+        $this->setUpContainerMock('tag.one', $tagged, $classes, true, true);
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidDefinitionException
+     * @expectedExceptionMessage Paginator service "INVALID" for tag "knp_paginator.injectable" on service "tag.one" could not be found.
+     */
+    public function testExceptionNoPaginator()
+    {
+        $tagged = array(
+            'tag.one' => array('paginator' => 'INVALID')
+        );
+
+        $classes = array(
+            'tag.one' => 'Knp\Bundle\PaginatorBundle\Definition\PaginatorAware'
+        );
+
+        $this->setUpContainerMock('tag.one', $tagged, $classes, false);
+        $this->pass->process($this->container);
+    }
+
+    private function setUpContainerMock($id, $services, $classes, $return = true, $exception = false)
+    {
+        $definition = new Definition($classes[$id]);
+
+        $this->container
+            ->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with(PaginatorAwarePass::PAGINATOR_AWARE_TAG)
+            ->will($this->returnValue($services))
+        ;
+
+        $this->container
+            ->expects($this->once())
+            ->method('getDefinition')
+            ->with($id)
+            ->will($this->returnValue($definition))
+        ;
+
+        if (!$exception) {
+            $this->container
+                ->expects($this->once())
+                ->method('has')
+                ->with($services[$id]['paginator'])
+                ->will($this->returnValue($return))
+            ;
+        }
+
+        return $definition;
+    }
+}


### PR DESCRIPTION
This makes it possible to tag services that the paginator should be
injected into. Those services need to implement PaginatorAwareInterface.
- Added PaginatorAwareInterface and PaginatorAware base class.
- Added CompilerPass to scan for 'knp_paginator.injectable' tag
- Added tests for PaginatorAwarePass
- Added Compiler to KnpPaginatorBundle class
- Added documentation about the DIC tag.
