### PR TITLE
Customisable sort css class names, combines with update to knp-components

### DIFF
--- a/Helper/Processor.php
+++ b/Helper/Processor.php
@@ -88,7 +88,7 @@ class Processor
         if ($sorted) {
             $direction = $params[$pagination->getPaginatorOption('sortDirectionParameterName')];
             $direction = (strtolower($direction) == 'asc') ? 'desc' : 'asc';
-            $class = $direction == 'asc' ? 'desc' : 'asc';
+            $class = ($direction == 'asc' ? $pagination->getPaginatorOption('cssClassNameDesc') : $pagination->getPaginatorOption('cssClassNameAsc'));
 
             if (isset($options['class'])) {
                 $options['class'] .= ' ' . $class;
@@ -96,7 +96,7 @@ class Processor
                 $options['class'] = $class;
             }
         } else {
-            $options['class'] = 'sortable';
+            $options['class'] = $pagination->getPaginatorOption('cssClassNameSortable');
         }
 
         if (is_array($title) && array_key_exists($direction, $title)) {


### PR DESCRIPTION
Combines with my update to knp-components to close #197 ( https://github.com/KnpLabs/KnpPaginatorBundle/issues/197 )
- set class names from Paginator options instead of using hard-coded values

(not sure how to issue a pull request across two repos!)
