### PR TITLE
Allow custom subscriber class to be a parameter

### DIFF
--- a/DependencyInjection/Compiler/PaginatorConfigurationPass.php
+++ b/DependencyInjection/Compiler/PaginatorConfigurationPass.php
@@ -24,6 +24,10 @@ class PaginatorConfigurationPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('knp_paginator.subscriber') as $id => $attributes) {
             // We must assume that the class value has been correcly filled, even if the service is created by a factory
             $class = $container->getDefinition($id)->getClass();
+            if (!class_exists($class) && substr($class, 0, 1) == '%' && substr($class, -1) == '%') {
+                $parameter = substr($class, 1, -1);
+                $class = $container->getParameter($parameter);
+            }
 
             $refClass = new \ReflectionClass($class);
             $interface = 'Symfony\Component\EventDispatcher\EventSubscriberInterface';


### PR DESCRIPTION
Hi,

Currently it's impossible to create a custom subscriber which class is a parameter.

This PR fixes it and allow to create subscriber like that:

```
<parameters>
    <parameter key="my.query.paginator.subscriber.class">My\Subscriber\MyQuerySubscriber</parameter>
</parameters>

<services>
    <service id="my.query.paginator.subscriber" class="%my.query.paginator.subscriber.class%">
        <tag name="knp_paginator.subscriber" />
    </service>
</services>
```
