### PR TITLE
Allow using parameters for knp_paginator.injectable tagged services

### DIFF
--- a/KnpPaginatorBundle.php
+++ b/KnpPaginatorBundle.php
@@ -13,6 +13,7 @@ use Knp\Bundle\PaginatorBundle\DependencyInjection\Compiler\PaginatorAwarePass;
 use Knp\Bundle\PaginatorBundle\DependencyInjection\Compiler\PaginatorConfigurationPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 
 class KnpPaginatorBundle extends Bundle
 {
@@ -23,6 +24,6 @@ class KnpPaginatorBundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new PaginatorConfigurationPass());
-        $container->addCompilerPass(new PaginatorAwarePass());
+        $container->addCompilerPass(new PaginatorAwarePass(), PassConfig::TYPE_BEFORE_REMOVING);
     }
 }


### PR DESCRIPTION
This pull request should solve https://github.com/KnpLabs/KnpPaginatorBundle/issues/207

What it does is just moving the PaginatorAwarePass in a later stage of the container's compilation in which all the parameter placeholders have been already substituted.

This is a duplicate for https://github.com/KnpLabs/KnpPaginatorBundle/pull/222 and https://github.com/KnpLabs/KnpPaginatorBundle/pull/215 and since none of them has been merged I would like to propose my solution.
