### PR TITLE
unset translationCount options before passing options array to template

### DIFF
--- a/Helper/Processor.php
+++ b/Helper/Processor.php
@@ -126,7 +126,12 @@ class Processor
             $options['title'] = $title;
         }
 
-        unset($options['absolute'], $options['translationDomain'], $options['translationParameters']);
+        unset(
+            $options['absolute'], 
+            $options['translationDomain'], 
+            $options['translationParameters'],
+            $options['translationCount']
+        );
 
         return array_merge(
             $pagination->getPaginatorOptions(),


### PR DESCRIPTION
When using the knp_pagination_sortable twig helper, an empty attribute translationCount was added to the DOM link. This modification unset it from the options array before passing it to the template.