### PR TITLE
Add support for parameters

### DIFF
--- a/DependencyInjection/Compiler/PaginatorAwarePass.php
+++ b/DependencyInjection/Compiler/PaginatorAwarePass.php
@@ -38,8 +38,13 @@ class PaginatorAwarePass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds(self::PAGINATOR_AWARE_TAG) as $id => $attributes) {
             $definition = $container->getDefinition($id);
+            $class = $definition->getClass();
+            // Class is parameter
+            if (strpos($class, '%') === 0) {
+                $class = $container->getParameter(trim($class, '%'));
+            }
 
-            $refClass = new \ReflectionClass($definition->getClass());
+            $refClass = new \ReflectionClass($class);
             if (!$refClass->implementsInterface(self::PAGINATOR_AWARE_INTERFACE)) {
                 throw new \InvalidArgumentException(
                     sprintf('Service "%s" must implement interface "%s".', $id, self::PAGINATOR_AWARE_INTERFACE)


### PR DESCRIPTION
See:
- https://github.com/richsage/RMSPushNotificationsBundle/blob/master/DependencyInjection/Compiler/AddHandlerPass.php#L35
- http://stackoverflow.com/questions/19266204/after-tagging-a-service-in-services-yml-symfony-starts-throwing-reflectionexcept
