### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,10 @@ variables as keys.
 
 ## Installation and configuration:
 
-Pretty simple with [Composer](http://packagist.org), add:
+Pretty simple with [Composer](http://packagist.org), run:
 
-```json
-{
-    "require": {
-        "knplabs/knp-paginator-bundle": "~2.4"
-    }
-}
+```sh
+composer require knplabs/knp-paginator-bundle
 ```
 
 If you use a `deps` file, add:


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
