### PR TITLE
Correct some small typos in documentation

### DIFF
--- a/Resources/doc/custom_pagination_subscribers.md
+++ b/Resources/doc/custom_pagination_subscribers.md
@@ -5,7 +5,7 @@ And when we have such a handy **Finder** component in symfony, its easily achiev
 
 ## Prepare environment
 
-I will asume we you just installed [symfony-standard](https://github.com/symfony/symfony-standard)
+I will assume we you just installed [symfony-standard](https://github.com/symfony/symfony-standard)
 edition and you install [KnpPaginatorBundle](https://github.com/knplabs/KnpPaginatorBundle).
 Follow the installation guide on these repositories, its very easy to setup.
 
@@ -65,7 +65,7 @@ for the **files** in the directory being paginated, max in 3 level depth.
 ## Register subscriber as service
 
 Next we need to tell **knp_paginator** about our new fancy subscriber which we intend
-to use in pagination. It is also very simple, create aditional service config file:
+to use in pagination. It is also very simple, create additional service config file:
 **../symfony-standard/src/Acme/DemoBundle/Resources/config/paginate.xml**
 
 ``` html

--- a/Resources/doc/templates.md
+++ b/Resources/doc/templates.md
@@ -1,7 +1,7 @@
 # Templates
 
 This document will describe how pagination can be rendered, extended and used in
-templates. For now theres only a sliding pagination supported, so all documentation
+templates. For now there's only a sliding pagination supported, so all documentation
 will reference it.
 
 ## Overriding default pagination template
@@ -105,7 +105,7 @@ In template:
 
 ## Choose the sorting direction
 
-The `knp_pagination_sortable()` template switch automaticly the sorting direction but sometimes you need to propose to your users to select the sorting direction of you list.
+The `knp_pagination_sortable()` template switch automatically the sorting direction but sometimes you need to propose to your users to select the sorting direction of you list.
 You can add an array at the end of `knp_pagination_sortable()` to choose the direction.
 
 ``` html


### PR DESCRIPTION
Just some minor typo found when reading documentation.
