### PR TITLE
Implemented sorting by multiple columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ public function listAction(Request $request)
 {# sorting of properties based on query components #}
     <th>{{ knp_pagination_sortable(pagination, 'Id', 'a.id') }}</th>
     <th{% if pagination.isSorted('a.Title') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'Title', 'a.title') }}</th>
+    <th>{{ knp_pagination_sortable(pagination, 'Release', ['a.date', 'a.time']) }}</th>
 </tr>
 
 {# table body #}
@@ -142,6 +143,7 @@ public function listAction(Request $request)
 <tr {% if loop.index is odd %}class="color"{% endif %}>
     <td>{{ article.id }}</td>
     <td>{{ article.title }}</td>
+    <td>{{ article.date | date('Y-m-d') }}, {{ article.time | date('H:i:s') }}</td>
 </tr>
 {% endfor %}
 </table>

--- a/Twig/Extension/PaginationExtension.php
+++ b/Twig/Extension/PaginationExtension.php
@@ -75,6 +75,9 @@ class PaginationExtension extends \Twig_Extension
      */
     public function sortable($pagination, $title, $key, $options = array(), $params = array(), $template = null)
     {
+        if (is_array($key)) {
+            $key = implode('+', $key);
+        }
         return $this->environment->render(
             $template ?: $pagination->getSortableTemplate(),
             $this->processor->sortable($pagination, $title, $key, $options, $params)


### PR DESCRIPTION
This patch is based on KnpLabs/knp-components#124 and enables `knp_pagination_sortable` twig function to generate URLs for sorting by multiple columns.

This feature is requested in issue #255 by others, too.

Example for usage:
```jinja
<tr>
    <th>{{ knp_pagination_sortable(pagination, 'Name', ['user.lastname', 'user.firstname']) }}</th>
</tr>
```