### PR TITLE
Use more relevant method to get current page value

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ public function listAction(Request $request)
     $paginator  = $this->get('knp_paginator');
     $pagination = $paginator->paginate(
         $query,
-        $request->query->get('page', 1)/*page number*/,
+        $request->query->getInt('page', 1)/*page number*/,
         10/*limit per page*/
     );
 

--- a/Resources/doc/custom_pagination_subscribers.md
+++ b/Resources/doc/custom_pagination_subscribers.md
@@ -119,7 +119,7 @@ public function testAction()
     $paginator = $this->get('knp_paginator');
     $files = $paginator->paginate(
         __DIR__.'/../',
-        $this->get('request')->query->get('page', 1),
+        $this->get('request')->query->getInt('page', 1),
         10
     );
     return compact('files');

--- a/Resources/doc/templates.md
+++ b/Resources/doc/templates.md
@@ -129,7 +129,7 @@ or manually with paginator options.
 $paginator = $this->get('knp_paginator');
 $pagination = $paginator->paginate(
     $query, // target to paginate
-    $this->get('request')->query->get('section', 1), // page parameter, now section
+    $this->get('request')->query->getInt('section', 1), // page parameter, now section
     10, // limit per page
     array('pageParameterName' => 'section', 'sortDirectionParameterName' => 'dir')
 );


### PR DESCRIPTION
Current page number is always integer so better to use `getInt` method instead of `int` one