### PR TITLE
Add paginator default options in container

### DIFF
--- a/DependencyInjection/KnpPaginatorExtension.php
+++ b/DependencyInjection/KnpPaginatorExtension.php
@@ -36,6 +36,7 @@ class KnpPaginatorExtension extends Extension
         $container->setParameter('knp_paginator.template.filtration', $config['template']['filtration']);
         $container->setParameter('knp_paginator.template.sortable', $config['template']['sortable']);
         $container->setParameter('knp_paginator.page_range', $config['page_range']);
+        $container->setParameter('knp_paginator.default_options', $config['default_options']);
 
         $paginatorDef = $container->getDefinition('knp_paginator');
         $paginatorDef->addMethodCall('setDefaultPaginatorOptions', array(array(


### PR DESCRIPTION
Hello,

I am currently writing a bridge for this bundle to integrate easily in mine (https://github.com/tgalopin/FOSMessageBundle) with just a line of configuration.

However, I currently have a problem of implementation: I can't easily find from my bundle which `pageParameterName` is set because it's not currently a container parameter. I'm using an ugly hack to do so for the moment: https://github.com/tgalopin/FOSMessageBundle/blob/master/Bridge/KnpPaginator/Paginator/StatementPaginator.php#L45

Adding this information as a container parameter (even read-only) would be great for usage of the data by other bundles. Perhaps an other option could be to add a getter of the options to the `Paginator`.