### PR TITLE
Hide underscores parameters from the url. Underscored variables shoul…

### DIFF
--- a/Subscriber/SlidingPaginationSubscriber.php
+++ b/Subscriber/SlidingPaginationSubscriber.php
@@ -29,6 +29,11 @@ class SlidingPaginationSubscriber implements EventSubscriberInterface
 
         $this->route = $request->attributes->get('_route');
         $this->params = array_merge($request->query->all(), $request->attributes->get('_route_params', array()));
+        foreach ($this->params as $key => $param) {
+            if (substr($key, 0, 1) == '_') {
+                unset($this->params[$key]);
+            }
+        }
     }
 
     public function pagination(PaginationEvent $event)


### PR DESCRIPTION
Hide underscores parameters from the url. Underscored variables should not be in the url and they will messup the esi esi includes. For example the _hash in the esi include will be put into the links in the paginator. Which obviously is wrong.

Revert change from PR: https://github.com/KnpLabs/KnpPaginatorBundle/pull/345