### PR TITLE
twitter_bootstrap_v3_pagination: Use rel attribute for next/prev buttons

### DIFF
--- a/Resources/views/Pagination/twitter_bootstrap_v3_pagination.html.twig
+++ b/Resources/views/Pagination/twitter_bootstrap_v3_pagination.html.twig
@@ -19,7 +19,7 @@
 
     {% if previous is defined %}
         <li>
-            <a href="{{ path(route, query|merge({(pageParameterName): previous})) }}">&laquo;&nbsp;{{ 'Previous'|trans }}</a>
+            <a rel="prev" href="{{ path(route, query|merge({(pageParameterName): previous})) }}">&laquo;&nbsp;{{ 'Previous'|trans }}</a>
         </li>
     {% else %}
         <li class="disabled">
@@ -74,7 +74,7 @@
 
     {% if next is defined %}
         <li>
-            <a href="{{ path(route, query|merge({(pageParameterName): next})) }}">{{ 'Next'|trans }}&nbsp;&raquo;</a>
+            <a rel="next" href="{{ path(route, query|merge({(pageParameterName): next})) }}">{{ 'Next'|trans }}&nbsp;&raquo;</a>
         </li>
     {% else %}
         <li class="disabled">


### PR DESCRIPTION
Make use of the "rel" attribute on "Next" and "Previous" buttons as this will provide a more semantic markup for crawlers.

See https://googlewebmastercentral.blogspot.com/2011/09/pagination-with-relnext-and-relprev.html
for additional information.