### PR TITLE
Fix depreciation notice when using knp_pagination_sortable on Symfony 2.8

### DIFF
--- a/Helper/Processor.php
+++ b/Helper/Processor.php
@@ -74,7 +74,7 @@ class Processor
     public function sortable(SlidingPagination $pagination, $title, $key, $options = array(), $params = array())
     {
         $options = array_merge(array(
-            'absolute' => false,
+            'absolute' => UrlGeneratorInterface::ABSOLUTE_PATH,
             'translationParameters' => array(),
             'translationDomain' => null,
             'translationCount' => null,


### PR DESCRIPTION
When using following code on a Symfony 2.8.x project, I'm getting the following depreciation:

```
{{ knp_pagination_sortable(pagination, 'Sample', 'sample.md5sum') }}
```

Depreciation message:

The hardcoded value you are using for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate method is deprecated since version 2.8 and will not be supported anymore in 3.0. Use the constants defined in the UrlGeneratorInterface instead. 

Stack trace:
```
...
appDevUrlGenerator::generate() (called from classes.php at line 1284)
Router::generate() (called from Processor.php at line 119)
Processor::sortable() (called from PaginationExtension.php at line 76)
PaginationExtension::sortable() (called from a0a6fac27b74bf7b3b41616caeca64d426f9ebc150f072f38d7b1ac8e2043cf4.php at line 62)
...
```

The following patch fixes the issue.
