### PR TITLE
fixing Deprecation on UrlGenerator::generate method

### DIFF
--- a/Helper/Processor.php
+++ b/Helper/Processor.php
@@ -116,7 +116,8 @@ class Processor
             )
         );
 
-        $options['href'] = $this->router->generate($pagination->getRoute(), $params, $options['absolute']);
+	$absolute = (isset($options['absolute']) && $options['absolute']) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH;
+        $options['href'] = $this->router->generate($pagination->getRoute(), $params, $absolute);
 
         if (null !== $options['translationDomain']) {
             if (null !== $options['translationCount']) {


### PR DESCRIPTION
The hardcoded value you are using for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate method is deprecated since version 2.8 and will not be supported anymore in 3.0. Use the constants defined in the UrlGeneratorInterface instead.

UrlGenerator::doGenerate() (called from appDevUrlGenerator.php at line 83)
appDevUrlGenerator::generate() (called from classes.php at line 1284)
Router::generate() (called from Processor.php at line 119)
Processor::sortable() (called from PaginationExtension.php at line 76)
PaginationExtension::sortable() (called from 4f92aaf9f593d6ca59f365e6483e314dde0a156fc6becf077ae381a174b1e1b1.php at line 110) 
