### PR TITLE
Make pagination_sortable w3c compatible

### DIFF
--- a/Helper/Processor.php
+++ b/Helper/Processor.php
@@ -130,7 +130,7 @@ class Processor
             $options['title'] = $title;
         }
 
-        unset($options['absolute'], $options['translationDomain'], $options['translationParameters']);
+        unset($options['absolute'], $options['translationParameters'], $options['translationDomain'], $options['translationCount']);
 
         return array_merge(
             $pagination->getPaginatorOptions(),


### PR DESCRIPTION
When checking for w3c_html, i got that error

	Error: Attribute translationcount not allowed on element a at this point.

	From line 156, column 5; to line 156, column 190

	<a translationCount="" id="action_sort_by_names" class="icon left sortable" href="/liste-des-joueurs?sort=u.username&amp;direction=asc&amp;page=1" title="Classer par ordre alphabétique">

	Attributes for element a:
	Global attributes
	href — Address of the hyperlink
	target — Browsing context for hyperlink navigation
	download — Whether to download the resource instead of navigating to it, and its file name if so
	ping — URLs to ping
	rel — Relationship between the document containing the hyperlink and the destination resource
	hreflang — Language of the linked resource
	type — Hint for the type of the referenced resource