### PR TITLE
Fixing deprecated message

### DIFF
--- a/Helper/Processor.php
+++ b/Helper/Processor.php
@@ -74,7 +74,7 @@ class Processor
     public function sortable(SlidingPagination $pagination, $title, $key, $options = array(), $params = array())
     {
         $options = array_merge(array(
-            'absolute' => false,
+            'absolute' => UrlGeneratorInterface::ABSOLUTE_URL,
             'translationParameters' => array(),
             'translationDomain' => null,
             'translationCount' => null,


### PR DESCRIPTION
The hardcoded value you are using for the $referenceType argument of the Symfony\Component\Routing\Generator\UrlGenerator::generate method is deprecated since version 2.8 and will not be supported anymore in 3.0. Use the constants defined in the UrlGeneratorInterface instead