### PR TITLE
Mark paginator service as lazy

### DIFF
--- a/DependencyInjection/KnpPaginatorExtension.php
+++ b/DependencyInjection/KnpPaginatorExtension.php
@@ -46,5 +46,7 @@ class KnpPaginatorExtension extends Extension
             'filterValueParameterName' => $config['default_options']['filter_value_name'],
             'distinct' => $config['default_options']['distinct']
         )));
+
+        $paginatorDef->setLazy(true);
     }
 }

--- a/README.md
+++ b/README.md
@@ -191,6 +191,12 @@ It defaults to ```knp_paginator```.
 The class that receives the KnpPaginator service must implement ```Knp\Bundle\PaginatorBundle\Definition\PaginatorAwareInterface```.
 If you're too lazy you can also just extend the ```Knp\Bundle\PaginatorBundle\Definition\PaginatorAware``` base class.
 
+#### Lazy service
+
+The `knp_paginator` service will be created lazily if the package `ocramius/proxy-manager` is installed.
+
+For more information about lazy services, consult the [Symfony documentation on dependency injection](https://symfony.com/doc/current/service_container/lazy_services.html).
+
 ###### XML configuration example
 
 ```xml


### PR DESCRIPTION
The service will often times be injected into more or less fat controllers (think of a CRUD controller) where it is only needed for one list action and thus it seems practical to just make the service definition lazy.

This is in line with the minimum requirements of the package itself.