### PR TITLE
Run tests for php 5.3 on ubuntu precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
+
+dist: trusty
+
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -9,6 +11,8 @@ php:
 
 matrix:
   include:
+    - php: 5.3
+      dist: precise
     - php: 5.6
       env: SYMFONY_VERSION='2.7.*'
     - php: 5.6


### PR DESCRIPTION
Since the beginning of September, Travis has changed the default OS to trusty but PHP 5.3 isn't available on it thus recent builds failed. This PR explicitly declares trusty has the default distribution used by jobs, and uses precise for php 5.3 job.