### PR TITLE
Prevent warning with Symfony 3.3 DI

### DIFF
--- a/Resources/config/paginator.xml
+++ b/Resources/config/paginator.xml
@@ -14,6 +14,8 @@
             <argument type="service" id="event_dispatcher" />
         </service>
 
+        <service id="Knp\Component\Pager\PaginatorInterface" alias="knp_paginator" />
+
         <service id="knp_paginator.subscriber.paginate" class="Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber">
             <tag name="knp_paginator.subscriber" />
         </service>


### PR DESCRIPTION
With Symfony 3.3 you can inject the dependencies without configure your services.
But when you inject the knp_paginator service with this system, like :
` __constructor(PaginatorInterface $paginator)`

you have the warning :
> Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "**knp_paginator**" service to "**Knp\Component\Pager\PaginatorInterface**" instead.

So to prevent this, we can make an alias.