### PR TITLE
Fix $_GET being replaced by default route params

### DIFF
--- a/Subscriber/SlidingPaginationSubscriber.php
+++ b/Subscriber/SlidingPaginationSubscriber.php
@@ -28,7 +28,7 @@ class SlidingPaginationSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
 
         $this->route = $request->attributes->get('_route');
-        $this->params = array_merge($request->query->all(), $request->attributes->get('_route_params', array()));
+        $this->params = array_merge($request->attributes->get('_route_params', array()), $request->query->all());
         foreach ($this->params as $key => $param) {
             if (substr($key, 0, 1) == '_') {
                 unset($this->params[$key]);


### PR DESCRIPTION
```yaml
list:
    path: /
    defaults: { _controller: SomeController::indexAction, sort: e.createdAt }
```
URL: `/?sort=e.name&direction=asc&page=1`

Processor will say that we are sorting via e.createdBy, but in reality it's sorted by e.name.
This is because if you utilize default sorting via routing definition, this routing definition currently replaces values in URL