### PR TITLE
Support PHPUnit 6

### DIFF
--- a/Tests/DependencyInjection/Compiler/PaginatorAwarePassTest.php
+++ b/Tests/DependencyInjection/Compiler/PaginatorAwarePassTest.php
@@ -3,6 +3,7 @@
 namespace Knp\Bundle\PaginatorBundle\Tests\DependencyInjection\Compiler;
 
 use Knp\Bundle\PaginatorBundle\DependencyInjection\Compiler\PaginatorAwarePass;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -10,7 +11,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * Class PaginatorAwarePassTest
  */
-class PaginatorAwarePassTest extends \PHPUnit_Framework_TestCase
+class PaginatorAwarePassTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -27,7 +28,7 @@ class PaginatorAwarePassTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $this->container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerBuilder')->getMock();
         $this->pass      = new PaginatorAwarePass();
     }
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "symfony/expression-language": "~2.7|~3.0|~4.0",
-        "phpunit/phpunit": "~4.8|~5"
+        "phpunit/phpunit": "~4.8.35|~5.4.3|~6.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I've added `PHPUnit 6` support.

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`~5.4.3`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.4.md#543---2016-06-09), that support the `PHPUnit\Framework\TestCase` namespace.