### PR TITLE
Add doc for issues of viewing `label_next` & `label_previous` + Add Arabic translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,24 @@ For more information about lazy services, consult the [Symfony documentation on 
 [doc_custom_pagination_subscriber]: https://github.com/KnpLabs/KnpPaginatorBundle/tree/master/Resources/doc/custom_pagination_subscribers.md "Custom pagination subscribers"
 [doc_templates]: https://github.com/KnpLabs/KnpPaginatorBundle/tree/master/Resources/doc/templates.md "Customizing Pagination templates"
 
+## Troubleshooting
+
+- Make sure the translator is activated in your symfony config :
+ 
+```yaml
+framework:
+    translator: { fallbacks: ['%locale%'] }
+```
+
+- If your locale is not available, create your own translation file in
+`app/Resources/translations/KnpPaginatorBundle.en.yml` (substitute en for your own language code if needed)
+. Then add these lines:
+
+```yaml
+label_next: Next
+label_previous: Previous
+```
+
 ## Maintainers
 
 - [@NiR-](https://github.com/NiR-)

--- a/Resources/translations/KnpPaginatorBundle.ar.xliff
+++ b/Resources/translations/KnpPaginatorBundle.ar.xliff
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="ar" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="0" resname="label_previous">
+        <source>label_previous</source>
+        <target>السابق</target>
+      </trans-unit>
+      <trans-unit id="1" resname="label_next">
+        <source>label_next</source>
+        <target>التالي</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
- Add `use_translator` configurations parameter (value should be either `true` or `false`) to avoid explicitly printing `label_next` & `label_previous` which caused confusion, such that users had to create their own template just to display '**Next**' instead of `label_next` and '**Previous**' instead of `label_previous`, see:
https://stackoverflow.com/questions/42103167
https://stackoverflow.com/questions/44554573
https://q-a-assistant.com/computer-internet-technology/1563434_getting-wrong-labels-from-knppaginatorbundle.html

- Add Arabic translation.