### PR TITLE
Update Bulma pagination template for version 0.6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ There are a few additional pagination templates, that could be used out of the b
 * `@KnpPaginator/Pagination/twitter_bootstrap_v3_pagination.html.twig`
 * `@KnpPaginator/Pagination/twitter_bootstrap_pagination.html.twig`
 * `@KnpPaginator/Pagination/foundation_v5_pagination.html.twig`
+* `@KnpPaginator/Pagination/bulma_pagination.html.twig`
 
 
 ## Usage examples:

--- a/Resources/doc/paginator_configuration.md
+++ b/Resources/doc/paginator_configuration.md
@@ -20,5 +20,8 @@ knp_paginator:
 There are a few additional pagination templates, that could be used out of the box in `knp_paginator.template.pagination` key:
 
 * `@KnpPaginator/Pagination/sliding.html.twig` (by default)
+* `@KnpPaginator/Pagination/twitter_bootstrap_v4_pagination.html.twig`
 * `@KnpPaginator/Pagination/twitter_bootstrap_v3_pagination.html.twig`
 * `@KnpPaginator/Pagination/twitter_bootstrap_pagination.html.twig`
+* `@KnpPaginator/Pagination/foundation_v5_pagination.html.twig`
+* `@KnpPaginator/Pagination/bulma_pagination.html.twig`

--- a/Resources/doc/templates.md
+++ b/Resources/doc/templates.md
@@ -155,12 +155,6 @@ Or even in Twig:
 
 ## Customize rendering
 
-As seen above, it is possible to pass parameters to the view by using the 4th
-argument of `knp_pagination_render`. It means that you can customize the template
-rendering.
-
-At this moment, only Bulma template is customizable.
-
 ### Bulma
 
 You can configure the position, the size, and make the buttons rounded or not:
@@ -168,17 +162,20 @@ You can configure the position, the size, and make the buttons rounded or not:
 - `size`: `'small'`, `'medium'`, or `'large'`. By default, size is not modified
 - `rounded`: `true` or `false`. By default it's `false`
 
-Here is an example:
+In your controller:
+```php
+$pagination->setCustomParameters([
+    'position' => 'centered',
+    'size' => 'large',
+    'rounded' => true,
+]);
+```
 
+or in the view:
 ```twig
-{{ knp_pagination_render(
-    pagination,
-    null,
-    {},  
-    {
-       'position': 'centered',
-       'size': 'large'
-       'rounded': true,
-    }
-) }}
+{{ knp_pagination_render(pagination, null, {}, {
+   'position': 'centered',
+   'size': 'large'
+   'rounded': true,
+}) }}
 ```

--- a/Resources/doc/templates.md
+++ b/Resources/doc/templates.md
@@ -153,3 +153,32 @@ Or even in Twig:
         ) }}
 ```
 
+## Customize rendering
+
+As seen above, it is possible to pass parameters to the view by using the 4th
+argument of `knp_pagination_render`. It means that you can customize the template
+rendering.
+
+At this moment, only Bulma template is customizable.
+
+### Bulma
+
+You can configure the position, the size, and make the buttons rounded or not:
+- `position`: `'left'`, `'centered'`, or `'right'`. By default it's `'left'` 
+- `size`: `'small'`, `'medium'`, or `'large'`. By default, size is not modified
+- `rounded`: `true` or `false`. By default it's `false`
+
+Here is an example:
+
+```twig
+{{ knp_pagination_render(
+    pagination,
+    null,
+    {},  
+    {
+       'position': 'centered',
+       'size': 'large'
+       'rounded': true,
+    }
+) }}
+```

--- a/Resources/views/Pagination/bulma_pagination.html.twig
+++ b/Resources/views/Pagination/bulma_pagination.html.twig
@@ -5,13 +5,13 @@
         {% if previous is defined %}
             <a class="pagination-previous" href="{{ path(route, query|merge({(pageParameterName): previous})) }}">{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% else %}
-            <a class="pagination-previous" disabled>Previous</a>
+            <a class="pagination-previous" disabled>{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% endif %}
 
         {% if next is defined %}
             <a class="pagination-next" href="{{ path(route, query|merge({(pageParameterName): next})) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% else %}
-            <a class="pagination-next" disabled>Next</a>
+            <a class="pagination-next" disabled>{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% endif %}
 
         <ul class="pagination-list">

--- a/Resources/views/Pagination/bulma_pagination.html.twig
+++ b/Resources/views/Pagination/bulma_pagination.html.twig
@@ -1,41 +1,58 @@
 {# bulma Sliding pagination control implementation #}
 
 {% if pageCount > 1 %}
-    <nav class="pagination">
+    <nav class="pagination" role="navigation" aria-label="pagination">
         {% if previous is defined %}
-            <a class="button" href="{{ path(route, query|merge({(pageParameterName): previous})) }}">&lt;</a>
+            <a class="pagination-previous" href="{{ path(route, query|merge({(pageParameterName): previous})) }}">{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% else %}
-            <a class="button" disabled>&lt;</a>
+            <a class="pagination-previous" disabled>Previous</a>
         {% endif %}
+
         {% if next is defined %}
-            <a class="button" href="{{ path(route, query|merge({(pageParameterName): next})) }}">&gt;</a>
+            <a class="pagination-next" href="{{ path(route, query|merge({(pageParameterName): next})) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% else %}
-            <a class="button" disabled>&gt;</a>
+            <a class="pagination-next" disabled>Next</a>
         {% endif %}
-        <ul>
+
+        <ul class="pagination-list">
             <li>
-                <a class="button" href="{{ path(route, query|merge({(pageParameterName): first})) }}">1</a>
+                {% if current == first %}
+                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, query|merge({(pageParameterName): first})) }}">1</a>
+                {% else %}
+                    <a class="pagination-link" href="{{ path(route, query|merge({(pageParameterName): first})) }}">1</a>
+                {% endif %}
             </li>
+
             {% if pagesInRange[0] - first >= 2 %}
                 <li>
-                    <span>…</span>
+                    <span class="pagination-ellipsis">&hellip;</span>
                 </li>
             {% endif %}
+
             {% for page in pagesInRange %}
                 {% if first != page and page != last %}
                     <li>
-                        <a class="button"
-                           href="{{ path(route, query|merge({(pageParameterName): page})) }}">{{ page }}</a>
+                        {% if page == current %}
+                            <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, query|merge({(pageParameterName): page})) }}">{{ page }}</a>
+                        {% else %}
+                            <a class="pagination-link" aria-label="Goto page {{ page }}" href="{{ path(route, query|merge({(pageParameterName): page})) }}">{{ page }}</a>
+                        {% endif %}
                     </li>
                 {% endif %}
             {% endfor %}
-            {% if  last - pagesInRange[pagesInRange|length - 1] >= 2 %}
+
+            {% if last - pagesInRange[pagesInRange|length - 1] >= 2 %}
                 <li>
-                    <span>…</span>
+                    <span class="pagination-ellipsis">&hellip;</span>
                 </li>
             {% endif %}
+
             <li>
-                <a class="button" href="{{ path(route, query|merge({(pageParameterName): last})) }}">{{ last }}</a>
+                {% if current == last %}
+                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, query|merge({(pageParameterName): last})) }}">{{ last }}</a>
+                {% else %}
+                    <a class="pagination-link" href="{{ path(route, query|merge({(pageParameterName): last})) }}">{{ last }}</a>
+                {% endif %}
             </li>
         </ul>
     </nav>

--- a/Resources/views/Pagination/bulma_pagination.html.twig
+++ b/Resources/views/Pagination/bulma_pagination.html.twig
@@ -1,7 +1,17 @@
 {# bulma Sliding pagination control implementation #}
 
+{% set position = position|default('left') %}
+{% set rounded = rounded|default(false) %}
+{% set size = size|default(null) %}
+
+{% set classes = ['pagination'] %}
+
+{% if position != 'left' %}{% set classes = classes|merge(['is-' ~ position]) %}{% endif %}
+{% if rounded %}{% set classes = classes|merge(['is-rounded']) %}{% endif %}
+{% if size != null %}{% set classes = classes|merge(['is-' ~ size]) %}{% endif %}
+
 {% if pageCount > 1 %}
-    <nav class="pagination" role="navigation" aria-label="pagination">
+    <nav class="{{ classes|join(' ') }}" role="navigation" aria-label="pagination">
         {% if previous is defined %}
             <a class="pagination-previous" href="{{ path(route, query|merge({(pageParameterName): previous})) }}">{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% else %}


### PR DESCRIPTION
Hey,

This PR update Bulma pagination template for version 0.6.x because it's broken (#399 was probably created during the version 0.2 of Bulma)

**This is what the current template renders:** 

![capture d ecran de 2018-02-19 22-04-55](https://user-images.githubusercontent.com/2103975/36397944-fb7c93a8-15c4-11e8-82c3-49f6750e76eb.png)

**And this is what my patch renders:**

Small pagination:
![capture d ecran de 2018-02-19 22-26-57](https://user-images.githubusercontent.com/2103975/36398005-5016f340-15c5-11e8-8c50-e5dc0592d47f.png)
![capture d ecran de 2018-02-19 22-27-05](https://user-images.githubusercontent.com/2103975/36398004-50000b62-15c5-11e8-9c2b-d88fa9da34af.png)

Big pagination:
![capture d ecran de 2018-02-19 22-25-46](https://user-images.githubusercontent.com/2103975/36398009-5094ad26-15c5-11e8-9f7e-db7c664103f7.png)
![capture d ecran de 2018-02-19 22-25-54](https://user-images.githubusercontent.com/2103975/36398008-506eb8c8-15c5-11e8-8123-dc2ff64870bf.png)
![capture d ecran de 2018-02-19 22-26-07](https://user-images.githubusercontent.com/2103975/36398007-5050d042-15c5-11e8-84f9-8cecbbb2e6e8.png)
![capture d ecran de 2018-02-19 22-26-17](https://user-images.githubusercontent.com/2103975/36398006-503313ea-15c5-11e8-91ac-f1e7fac0cad2.png)


And also, I made the Bulma render customizable ([doc](https://github.com/Kocal/KnpPaginatorBundle/blob/feature/update-bulma-pagination-template/Resources/doc/templates.md#bulma)). You can customize the position, the size, and make buttons rounded or not.


Thanks