### PR TITLE
Use twig parameters instead of query parameters

### DIFF
--- a/Resources/views/Pagination/twitter_bootstrap_v3_sortable_link.html.twig
+++ b/Resources/views/Pagination/twitter_bootstrap_v3_sortable_link.html.twig
@@ -9,8 +9,8 @@
 
 <a{% for attr, value  in options %} {{ attr }}="{{ value }}"{% endfor %} style="color: #000;">
     <span class="pull-right">
-        {% if app.request.get('sort') == key %}
-            {% if app.request.get('direction') == 'desc' %}
+        {% if sorted %}
+            {% if direction == 'desc' %}
                 <i class="glyphicon glyphicon-sort-by-attributes-alt"></i>
             {% else %}
                 <i class="glyphicon glyphicon-sort-by-attributes"></i>


### PR DESCRIPTION
In twitter_bootstrap_v3_sortable_link.html.twig,
I have change the request query parameters for the twig extension parameters.

Because if we change the parrameter out and direction via the configuration file.
the query parameters will automatically be set to null.
