### PR TITLE
IsSorted on multiple field

### DIFF
--- a/Pagination/SlidingPagination.php
+++ b/Pagination/SlidingPagination.php
@@ -88,6 +88,10 @@ class SlidingPagination extends AbstractPagination
     {
         $params = array_merge($this->params, $params);
 
+        if(is_array($key)) {
+            $key = implode('+', $key);
+        }
+
         if ($key === null) {
             return isset($params[$this->getPaginatorOption('sortFieldParameterName')]);
         }


### PR DESCRIPTION
Multiple fields sorting has been added, that was a great improvement for small changes.
But how to check `isSorted` on it ?
The way `pagination.isSorted('fields1+field2')`, well done it works, but why not apply the same patch for it ?

We can keep the same field writing way.