### PR TITLE
Add Materialize CSS pagination template

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ There are a few additional pagination templates, that could be used out of the b
 * `@KnpPaginator/Pagination/foundation_v5_pagination.html.twig`
 * `@KnpPaginator/Pagination/bulma_pagination.html.twig`
 * `@KnpPaginator/Pagination/semantic_ui_pagination.html.twig`
+* `@KnpPaginator/Pagination/materialize_pagination.html.twig`
 
 
 ## Usage examples:

--- a/Resources/views/Pagination/materialize_pagination.html.twig
+++ b/Resources/views/Pagination/materialize_pagination.html.twig
@@ -1,0 +1,84 @@
+{#
+/**
+ * @file
+ * Materialize pagination control implementation.
+ *
+ * View that can be used with the pagination module
+ * from the Materialize CSS
+ * https://materializecss.com/pagination.html
+ *
+ * @author Leonardo Bressan Motyczka <leomoty@gmail.com>
+ */
+#}
+
+{% if pageCount > 1 %}
+    <ul class="pagination">
+        {% if first is defined and current != first %}
+            <li class="waves-effect">
+                <a href="{{ path(route, query|merge({(pageParameterName): first})) }}">
+                    <i class="material-icons">first_page</i>
+                </a>
+            </li>
+        {% else %}
+            <li class="disabled">
+                <a href="#!">
+                    <i class="material-icons">first_page</i>
+                </a>
+            </li>
+        {% endif %}
+
+        {% if previous is defined %}
+            <li class="waves-effect">
+                <a href="{{ path(route, query|merge({(pageParameterName): previous})) }}">
+                    <i class="material-icons">chevron_left</i>
+                </a>
+            </li>
+        {% else %}
+            <li class="disabled">
+                <a href="#!">
+                    <i class="material-icons">chevron_left</i>
+                </a>
+            </li>
+        {% endif %}
+
+        {% for page in pagesInRange %}
+            {% if page != current %}
+                <li class="waves-effect">
+                    <a href="{{ path(route, query|merge({(pageParameterName): page})) }}">{{ page }}</a>
+                </li>
+            {% else %}
+                <li class="active">
+                    <a href="#!">{{ page }}</a>
+                </li>
+            {% endif %}
+        {% endfor %}
+
+        {% if next is defined %}
+            <li class="waves-effect">
+                <a href="{{ path(route, query|merge({(pageParameterName): next})) }}">
+                    <i class="material-icons">chevron_right</i>
+                </a>
+            </li>
+        {% else %}
+            <li class="disabled">
+                <a href="#!">
+                    <i class="material-icons">chevron_right</i>
+                </a>
+            </li>
+        {% endif %}
+
+        {% if last is defined and current != last %}
+            <li class="waves-effect">
+                <a href="{{ path(route, query|merge({(pageParameterName): last})) }}">
+                    <i class="material-icons">last_page</i>
+                </a>
+            </li>
+        {% else %}
+            <li class="disabled">
+                <a href="#!">
+                    <i class="material-icons">last_page</i>
+                </a>
+            </li>
+        {% endif %}
+    </ul>
+{% endif %}


### PR DESCRIPTION
I have been using this for a while, a few days I was looking to migrate my application to Symfony v4 and noticed there was no default template for Materialize. I just cleaned up a bit and added the header the other templates had.

The implementation is based on https://materializecss.com/pagination.html.