### PR TITLE
remove php 5.3 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ php:
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
     - php: 5.6
       env: SYMFONY_VERSION='2.7.*'
     - php: 5.6

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php":                      ">=5.3.3",
+        "php":                      ">=5.4.0",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "knplabs/knp-components":   "~1.2",
         "twig/twig":                "~1.12|~2"


### PR DESCRIPTION
As `composer install --dev` task keeps having an OOM on travis and
there's no way to fix this. Moreover, PHP 5.3 is EOL since 2014.