### PR TITLE
[RFR] drop support for EOL PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 dist: trusty
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php":                      ">=5.4.0",
+        "php":                      ">=5.6.0",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "knplabs/knp-components":   "~1.2",
         "twig/twig":                "~1.12|~2"


### PR DESCRIPTION
cf. http://php.net/supported-versions.php

Related to https://github.com/KnpLabs/KnpPaginatorBundle/pull/505#issuecomment-428172350