### PR TITLE
Require symfony/translation explicitly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php":                      ">=5.6.0",
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
+        "symfony/translation":      "~2.7|~3.0|~4.0",
         "knplabs/knp-components":   "~1.2",
         "twig/twig":                "~1.12|~2"
     },


### PR DESCRIPTION
I submitted [a PR to add the bundle to the recipes-contrib](https://github.com/symfony/recipes-contrib/pull/588) and it failed because of the `translator` service. 

https://github.com/KnpLabs/KnpPaginatorBundle/issues/479 is about this too, so I've just added the dependency explicitly, the question is whether the dependency is required explicitly or make it optional.