### PR TITLE
Symfony 5, Twig 3, & PHP 7.4 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4snapshot
@@ -9,14 +8,14 @@ php:
 
 matrix:
   include:
-    - php: 7.1
-      env: DEPENDENCIES='dev' SYMFONY_VERSION='3.4.*@dev'
-    - php: 7.1
-      env: DEPENDENCIES='dev' SYMFONY_VERSION='4.2.*'
     - php: 7.2
-      env: DEPENDENCIES='dev' SYMFONY_VERSION='4.2.*'
-    - php: 7.3
+      env: DEPENDENCIES='dev' SYMFONY_VERSION='4.3.*@dev'
+    - php: 7.2
       env: DEPENDENCIES='dev' SYMFONY_VERSION='4.3.*'
+    - php: 7.3
+      env: DEPENDENCIES='dev' SYMFONY_VERSION='4.4.*'
+    - php: 7.4snapshot
+      env: DEPENDENCIES='dev' SYMFONY_VERSION='5.0.*'
   fast_finish: true
   allow_failures:
     - php: nightly

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -10,8 +10,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('knp_paginator');
-        // BC layer for symfony/config < 4.2
-        $rootNode = \method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('knp_paginator');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->addDefaultsIfNotSet()

--- a/Helper/Processor.php
+++ b/Helper/Processor.php
@@ -4,7 +4,7 @@ namespace Knp\Bundle\PaginatorBundle\Helper;
 
 use Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Pagination data processor.
@@ -133,11 +133,12 @@ final class Processor
         $options['href'] = $this->router->generate($pagination->getRoute(), $params, $options['absolute']);
 
         if (null !== $options['translationDomain']) {
-            if (null !== $options['translationCount']) {
-                $title = $this->translator->transChoice($title, $options['translationCount'], $options['translationParameters'], $options['translationDomain']);
+            if (null === $options['translationCount']) {
+                $translationParameters = $options['translationParameters'];
             } else {
-                $title = $this->translator->trans($title, $options['translationParameters'], $options['translationDomain']);
+                $translationParameters = $options['translationParameters'] + ['%count%' => $options['translationCount']];
             }
+            $title = $this->translator->trans($title, $translationParameters, $options['translationDomain']);
         }
 
         if (!isset($options['title'])) {

--- a/Subscriber/SlidingPaginationSubscriber.php
+++ b/Subscriber/SlidingPaginationSubscriber.php
@@ -5,7 +5,7 @@ namespace Knp\Bundle\PaginatorBundle\Subscriber;
 use Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination;
 use Knp\Component\Pager\Event\PaginationEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 final class SlidingPaginationSubscriber implements EventSubscriberInterface
@@ -19,7 +19,7 @@ final class SlidingPaginationSubscriber implements EventSubscriberInterface
         $this->options = $options;
     }
 
-    public function onKernelRequest(GetResponseEvent $event): void
+    public function onKernelRequest(ResponseEvent $event): void
     {
         if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
             return;

--- a/Tests/DependencyInjection/Compiler/PaginatorAwarePassTest.php
+++ b/Tests/DependencyInjection/Compiler/PaginatorAwarePassTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Reference;
 final class PaginatorAwarePassTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit\Framework\MockObject\MockObject
      */
     public $container;
 

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,16 @@
         }
     ],
     "require": {
-        "php":                      "^7.1",
-        "knplabs/knp-components":   "^1.3 || ^2.0",
-        "symfony/framework-bundle": "^3.4 || ^4.0",
-        "symfony/translation":      "^3.4 || ^4.0",
-        "twig/twig":                "^2.0"
+        "php":                      "^7.2",
+        "knplabs/knp-components":   "^2.0",
+        "symfony/framework-bundle": "^4.3 || ^5.0",
+        "symfony/translation":      "^4.3 || ^5.0",
+        "twig/twig":                "^2.0 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4 || ^8.0",
-        "symfony/expression-language": "^3.4 || ^4.0"
+        "phpunit/phpunit": "^7.5 || ^8.4",
+        "symfony/expression-language": "^4.3 || ^5.0",
+        "symfony/templating": "^3.4 || ^4.0"
     },
     "autoload": {
         "psr-4": {
@@ -36,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.1.x-dev"
+            "dev-master": "5.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
I may have started this a (long) while ago, and should have gotten back to :innocent: 

**Edit:** Summary of current changes:    
- Bump minimum PHP ^7.2
- Symfony components ^4.3 || ^5.0
- Twig ^2.0 || ^3.0
- PHPUnit ^7.5 || ^8.4
- `knplabs/knp-components` ^2.0
- Require (dev) for `symfony/templating` (dropped in SF 5.0)
- Remove deprecation workaround for `TreeBuilder`
- Remove deprecated use of `transChoice()`
- Tests Symfony 5 on Travis
- Tests PHP 7.4 (snapshot) on Travis

@garak I figured it might be overkill to add assertions in the two methods that lost their type hint, but happy to add quickly if you'd like.

Supercedes #580
Supercedes #581