### PR TITLE
Make `PaginatorAware` abstract

### DIFF
--- a/src/Definition/AbstractPaginatorAware.php
+++ b/src/Definition/AbstractPaginatorAware.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Knp\Bundle\PaginatorBundle\Definition;
+
+use Knp\Component\Pager\Paginator;
+
+/**
+ * This is a base class that can be extended if you're too lazy to implement PaginatorAwareInterface yourself.
+ */
+abstract class AbstractPaginatorAware implements PaginatorAwareInterface
+{
+    /**
+     * @var Paginator
+     */
+    private $paginator;
+
+    /**
+     * Sets the KnpPaginator instance.
+     */
+    public function setPaginator(Paginator $paginator): PaginatorAwareInterface
+    {
+        $this->paginator = $paginator;
+
+        return $this;
+    }
+
+    /**
+     * Returns the KnpPaginator instance.
+     */
+    public function getPaginator(): Paginator
+    {
+        return $this->paginator;
+    }
+}

--- a/src/Definition/PaginatorAware.php
+++ b/src/Definition/PaginatorAware.php
@@ -9,7 +9,7 @@ use Knp\Component\Pager\Paginator;
  *
  * This is a base class that can be extended if you're too lazy to implement PaginatorAwareInterface yourself.
  */
-final class PaginatorAware implements PaginatorAwareInterface
+abstract class PaginatorAware implements PaginatorAwareInterface
 {
     /**
      * @var Paginator

--- a/src/Definition/PaginatorAware.php
+++ b/src/Definition/PaginatorAware.php
@@ -2,35 +2,15 @@
 
 namespace Knp\Bundle\PaginatorBundle\Definition;
 
-use Knp\Component\Pager\Paginator;
+@trigger_error('The '.__NAMESPACE__.'\PaginatorAware class is deprecated since knplabs/knp-paginator-bundle 5.x. Use '.AbstractPaginatorAware::class.' instead.', E_USER_DEPRECATED);
 
 /**
  * Class PaginatorAware.
  *
  * This is a base class that can be extended if you're too lazy to implement PaginatorAwareInterface yourself.
+ *
+ * @deprecated since knplabs/knp-paginator-bundle 5.x
  */
-abstract class PaginatorAware implements PaginatorAwareInterface
+abstract class PaginatorAware extends AbstractPaginatorAware
 {
-    /**
-     * @var Paginator
-     */
-    private $paginator;
-
-    /**
-     * Sets the KnpPaginator instance.
-     */
-    public function setPaginator(Paginator $paginator): PaginatorAwareInterface
-    {
-        $this->paginator = $paginator;
-
-        return $this;
-    }
-
-    /**
-     * Returns the KnpPaginator instance.
-     */
-    public function getPaginator(): Paginator
-    {
-        return $this->paginator;
-    }
 }


### PR DESCRIPTION
This makes `PaginatorAware` abstract, allowing to extend from it.
Since this class was made final in `4.0.0` version, I think this should be merged for 4.x before, then the fix should bubble up to 5.x.

Fixes #592.