### PR TITLE
Updates README.md introducing the use of isSorted with multiple fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ public function listAction(EntityManagerInterface $em, PaginatorInterface $pagin
         {# sorting of properties based on query components #}
         <th>{{ knp_pagination_sortable(pagination, 'Id', 'a.id') }}</th>
         <th{% if pagination.isSorted('a.Title') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'Title', 'a.title') }}</th>
-        <th>{{ knp_pagination_sortable(pagination, 'Release', ['a.date', 'a.time']) }}</th>
+        <th{% if pagination.isSorted(['a.date', 'a.time']) %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'Release', ['a.date', 'a.time']) }}</th>
     </tr>
 
     {# table body #}


### PR DESCRIPTION
This PR simply updates the doc (README.md) showing how to use the `isSorted` method with multiple fields.
IMHO a better way would be to update the `isSorted` method itself, in order to keep it consistent with the `knp_pagination_sortable` one, as described in #492 