### PR TITLE
Add limit to number of pages

### DIFF
--- a/src/Pagination/SlidingPagination.php
+++ b/src/Pagination/SlidingPagination.php
@@ -15,6 +15,9 @@ final class SlidingPagination extends AbstractPagination implements SlidingPagin
     /** @var int */
     private $pageRange = 5;
 
+    /** @var int|null */
+    private $pageLimit = null;
+
     /** @var string|null */
     private $template;
 
@@ -82,6 +85,11 @@ final class SlidingPagination extends AbstractPagination implements SlidingPagin
     public function setPageRange(int $range): void
     {
         $this->pageRange = \abs($range);
+    }
+
+    public function setPageLimit(?int $limit): void
+    {
+        $this->pageLimit = $limit;
     }
 
     /**
@@ -215,7 +223,13 @@ final class SlidingPagination extends AbstractPagination implements SlidingPagin
 
     public function getPageCount(): int
     {
-        return \ceil($this->totalCount / $this->numItemsPerPage);
+        $count = \ceil($this->totalCount / $this->numItemsPerPage);
+
+        if ($this->pageLimit !== null) {
+            return \min($count, $this->pageLimit);
+        }
+
+        return $count;
     }
 
     public function getPaginatorOptions(): ?array

--- a/tests/Pagination/SlidingPaginationTest.php
+++ b/tests/Pagination/SlidingPaginationTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Knp\Bundle\PaginatorBundle\Tests\Pagination;
 
@@ -8,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Class SlidingPaginationTest.
  */
-class SlidingPaginationTest extends TestCase
+final class SlidingPaginationTest extends TestCase
 {
     /**
      * @var SlidingPagination
@@ -23,7 +25,7 @@ class SlidingPaginationTest extends TestCase
     /**
      * @dataProvider getPageLimitData
      */
-    public function testGetPageCount(int $expected, int $totalItemCount, int $itemsPerPage, ?int $pageLimit)
+    public function testGetPageCount(int $expected, int $totalItemCount, int $itemsPerPage, ?int $pageLimit): void
     {
         $this->pagination->setTotalItemCount($totalItemCount);
         $this->pagination->setItemNumberPerPage($itemsPerPage);

--- a/tests/Pagination/SlidingPaginationTest.php
+++ b/tests/Pagination/SlidingPaginationTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Knp\Bundle\PaginatorBundle\Tests\Pagination;
+
+use Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination;
+use PHPUnit\Framework\TestCase;
+
+
+/**
+ * @copyright 2020 PB Web Media B.V.
+ */
+class SlidingPaginationTest extends TestCase
+{
+    /**
+     * @var SlidingPagination
+     */
+    private $pagination;
+
+    protected function setUp(): void
+    {
+        $this->pagination = new SlidingPagination([]);
+    }
+
+    /**
+     * @dataProvider getPageLimitData
+     */
+    public function testGetPageCount(int $expected, int $totalItemCount, int $itemsPerPage, ?int $pageLimit)
+    {
+        $this->pagination->setTotalItemCount($totalItemCount);
+        $this->pagination->setItemNumberPerPage($itemsPerPage);
+        $this->pagination->setPageLimit($pageLimit);
+
+        $this->assertSame($expected, $this->pagination->getPageCount());
+    }
+
+    public function getPageLimitData(): array
+    {
+        return [
+            'Normal' => [5, 120, 25, null],
+            'No pages' => [0, 0, 25, null],
+            'Pages limited to 3' => [3, 400, 25, 3],
+            'Pages limited to 3, but limit not hit' => [2, 26, 25, 3],
+        ];
+    }
+}

--- a/tests/Pagination/SlidingPaginationTest.php
+++ b/tests/Pagination/SlidingPaginationTest.php
@@ -5,9 +5,8 @@ namespace Knp\Bundle\PaginatorBundle\Tests\Pagination;
 use Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination;
 use PHPUnit\Framework\TestCase;
 
-
 /**
- * @copyright 2020 PB Web Media B.V.
+ * Class SlidingPaginationTest.
  */
 class SlidingPaginationTest extends TestCase
 {


### PR DESCRIPTION
This adds a way to set an upper limit on the number of pages the paginator shows.

Here's a bit of an explanation why:

Our websites are search engines and we categorize millions of items. In these categories we don't want use visitors to go past page 100 to reduce the load on our elasticsearch and caching servers.
With this fix, the paginator stops at the configured limit.

Before version 4.0 we just created a custom pagination class which extended the `SlidingPagination` class, but since it has been declared `final` we no longer can. There also seems no easy way to hook into this class and modify its behavior.