### PR TITLE
Bugfix: Use array_replace with query parameters

### DIFF
--- a/src/Subscriber/SlidingPaginationSubscriber.php
+++ b/src/Subscriber/SlidingPaginationSubscriber.php
@@ -28,7 +28,7 @@ final class SlidingPaginationSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
 
         $this->route = $request->attributes->get('_route');
-        $this->params = \array_merge($request->query->all(), $request->attributes->get('_route_params', []));
+        $this->params = \array_replace($request->query->all(), $request->attributes->get('_route_params', []));
         foreach ($this->params as $key => $param) {
             if ('_' == \substr($key, 0, 1)) {
                 unset($this->params[$key]);


### PR DESCRIPTION
The [PHP docs](https://www.php.net/manual/en/language.types.array.php) state that:

> A key may be either an integer or a string. If a key is the standard representation of an integer, it will be interpreted as such (i.e. "8" will be interpreted as 8, while "08" will be interpreted as "08").

Since `ParameterBag`'s use array's internally and `all()` just returns that array, we might get integers as parameter keys.

`array_merge` resets integer keys when merging, so any integer might change. `array_replace` on the other hand leaves the keys alone, so it is a more suitable function to use in this case.