### PR TITLE
add page_out_of_range and default_limit configuration parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "knplabs/knp-components": "^2.0",
+        "knplabs/knp-components": "^2.4",
         "symfony/config": "^4.3 || ^5.0",
         "symfony/dependency-injection": "^4.3 || ^5.0",
         "symfony/event-dispatcher": "^4.3 || ^5.0",

--- a/docs/paginator_configuration.md
+++ b/docs/paginator_configuration.md
@@ -15,6 +15,8 @@ knp_paginator:
         sort_field_name: sort          # sort field query parameter name; to disable sorting set this field to ~ (null)
         sort_direction_name: direction # sort direction query parameter name
         distinct: true                 # ensure distinct results, useful when ORM queries are using GROUP BY statements
+        page_out_of_range: ignore      # if page number exceeds the last page. Options: 'fix'(return last page); 'throwException'
+        default_limit: 10              # default number of items per page
     template:
         pagination: @KnpPaginator/Pagination/sliding.html.twig     # sliding pagination controls template
         sortable: @KnpPaginator/Pagination/sortable_link.html.twig # sort link template

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Bundle\PaginatorBundle\DependencyInjection;
 
+use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -24,6 +25,8 @@ final class Configuration implements ConfigurationInterface
                         ->scalarNode('filter_value_name')->defaultValue('filterValue')->end()
                         ->scalarNode('page_name')->defaultValue('page')->end()
                         ->booleanNode('distinct')->defaultTrue()->end()
+                        ->scalarNode('page_out_of_range')->defaultValue(PaginatorInterface::PAGE_OUT_OF_RANGE_IGNORE)->end()
+                        ->scalarNode('default_limit')->defaultValue(PaginatorInterface::DEFAULT_LIMIT_VALUE)->end()
                     ->end()
                 ->end()
                 ->arrayNode('template')

--- a/src/DependencyInjection/KnpPaginatorExtension.php
+++ b/src/DependencyInjection/KnpPaginatorExtension.php
@@ -34,6 +34,8 @@ final class KnpPaginatorExtension extends Extension
         $container->setParameter('knp_paginator.template.sortable', $config['template']['sortable']);
         $container->setParameter('knp_paginator.page_range', $config['page_range']);
         $container->setParameter('knp_paginator.page_limit', $config['page_limit']);
+        $container->setParameter('knp_paginator.page_out_of_range', $config['page_out_of_range']);
+        $container->setParameter('knp_paginator.default_limit', $config['default_limit']);
 
         $paginatorDef = $container->getDefinition('knp_paginator');
         $paginatorDef->addMethodCall('setDefaultPaginatorOptions', [[
@@ -43,6 +45,8 @@ final class KnpPaginatorExtension extends Extension
             'filterFieldParameterName' => $config['default_options']['filter_field_name'],
             'filterValueParameterName' => $config['default_options']['filter_value_name'],
             'distinct' => $config['default_options']['distinct'],
+            'pageOutOfRange' => $config['default_options']['page_out_of_range'],
+            'defaultLimit' => $config['default_options']['default_limit'],
         ]]);
 
         $paginatorDef->setLazy(true);

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -3,6 +3,7 @@
 namespace Knp\Bundle\PaginatorBundle\Tests\DependencyInjection;
 
 use Knp\Bundle\PaginatorBundle\DependencyInjection\Configuration;
+use Knp\Component\Pager\PaginatorInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -44,6 +45,8 @@ final class ConfigurationTest extends TestCase
                 'filter_value_name' => 'filterValue',
                 'page_name' => 'page',
                 'distinct' => true,
+                'page_out_of_range' => PaginatorInterface::PAGE_OUT_OF_RANGE_IGNORE,
+                'default_limit' => PaginatorInterface::DEFAULT_LIMIT_VALUE,
             ],
             'template' => [
                 'pagination' => '@KnpPaginator/Pagination/sliding.html.twig',
@@ -67,6 +70,8 @@ final class ConfigurationTest extends TestCase
                 'filter_value_name' => 'there',
                 'page_name' => 'bar',
                 'distinct' => false,
+                'page_out_of_range' => PaginatorInterface::PAGE_OUT_OF_RANGE_FIX,
+                'default_limit' => 20,
             ],
             'template' => [
                 'pagination' => '@KnpPaginator/Pagination/foo.html.twig',


### PR DESCRIPTION
Allow default options page_out_of_range and default_limit to be configured.

Some test are failing, but those are the same that were already failing in the [previous merge](https://travis-ci.org/github/KnpLabs/KnpPaginatorBundle/jobs/703421594).