### PR TITLE
restrict symfony/dependency-injection version to 5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.2",
         "knplabs/knp-components": "^2.0",
         "symfony/config": "^4.3 || ^5.0",
-        "symfony/dependency-injection": "^4.3 || ^5.0",
+        "symfony/dependency-injection": "^4.3 || 5.0.*",
         "symfony/event-dispatcher": "^4.3 || ^5.0",
         "symfony/http-foundation": "^4.3 || ^5.0",
         "symfony/http-kernel": "^4.3 || ^5.0",


### PR DESCRIPTION
This PR fixes #646 