### PR TITLE
Update docs with PHP file config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ knp_paginator:
         sortable: '@KnpPaginator/Pagination/sortable_link.html.twig' # sort link template
         filtration: '@KnpPaginator/Pagination/filtration.html.twig'  # filters template
 ```
-#### PHP: (Symfony 5.x)
+#### PHP:
 ```php
 // config/packages/paginator.php
 
@@ -100,19 +100,19 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $configurator): void
 {
     $configurator->extension('knp_paginator', [
-        'page_range' => 5,
+        'page_range' => 5,                        // number of links showed in the pagination menu (e.g: you have 10 pages, a page_range of 3, on the 5th page you'll see links
         'default_options' => [
-            'page_name' => 'page',
-            'sort_field_name' => 'sort',
-            'sort_direction_name' => 'direction',
-            'distinct' => true,
-            'filter_field_name' => 'filterField',
-            'filter_value_name' => 'filterValue'
+            'page_name' => 'page',                // page query parameter name
+            'sort_field_name' => 'sort',          // sort field query parameter name
+            'sort_direction_name' => 'direction', // sort direction query parameter name
+            'distinct' => true,                   // ensure distinct results, useful when ORM queries are using GROUP BY statements
+            'filter_field_name' => 'filterField', // filter field query parameter name
+            'filter_value_name' => 'filterValue'  // filter value query parameter name
         ],
         'template' => [
-            'pagination' => '@KnpPaginator/Pagination/sliding.html.twig',
-            'sortable' => '@KnpPaginator/Pagination/sortable_link.html.twig',
-            'filtration' => '@KnpPaginator/Pagination/filtration.html.twig'
+            'pagination' => '@KnpPaginator/Pagination/sliding.html.twig',     // sliding pagination controls template
+            'sortable' => '@KnpPaginator/Pagination/sortable_link.html.twig', // sort link template
+            'filtration' => '@KnpPaginator/Pagination/filtration.html.twig'   // filters template
         ]
     ]);
 };

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ public function registerBundles()
 
 You can configure default query parameter names and templates
 
+#### YAML:
 ```yaml
 knp_paginator:
     page_range: 5                       # number of links showed in the pagination menu (e.g: you have 10 pages, a page_range of 3, on the 5th page you'll see links to page 4, 5, 6)
@@ -87,6 +88,34 @@ knp_paginator:
         pagination: '@KnpPaginator/Pagination/sliding.html.twig'     # sliding pagination controls template
         sortable: '@KnpPaginator/Pagination/sortable_link.html.twig' # sort link template
         filtration: '@KnpPaginator/Pagination/filtration.html.twig'  # filters template
+```
+#### PHP: (Symfony 5.x)
+```php
+// config/packages/paginator.php
+
+<?php declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $configurator): void
+{
+    $configurator->extension('knp_paginator', [
+        'page_range' => 5,
+        'default_options' => [
+            'page_name' => 'page',
+            'sort_field_name' => 'sort',
+            'sort_direction_name' => 'direction',
+            'distinct' => true,
+            'filter_field_name' => 'filterField',
+            'filter_value_name' => 'filterValue'
+        ],
+        'template' => [
+            'pagination' => '@KnpPaginator/Pagination/sliding.html.twig',
+            'sortable' => '@KnpPaginator/Pagination/sortable_link.html.twig',
+            'filtration' => '@KnpPaginator/Pagination/filtration.html.twig'
+        ]
+    ]);
+};
 ```
 
 #### Additional pagination templates


### PR DESCRIPTION
Symfony 6 will recommend the use of PHP files instead of YAML for config, so it's convenient to show users how to perform PHP config from now on.