### PR TITLE
allow knp-components 3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,7 @@
 .php_cs          export-ignore
 .travis.yml      export-ignore
 CHANGELOG.md     export-ignore
+CODE_OF_CONDUCT.md export-ignore
+CONTRIBUTING.md  export-ignore
 phpunit.xml.dist export-ignore
 tests            export-ignore

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "knplabs/knp-components": "^2.4",
+        "knplabs/knp-components": "^2.4 || ^3.0",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0",
@@ -28,7 +28,7 @@
         "twig/twig": "^2.0 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
+        "phpunit/phpunit": "^8.5 || ^9.4",
         "symfony/expression-language": "^4.4 || ^5.0",
         "symfony/templating": "^4.4 || ^5.0"
     },
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.3.x-dev"
+            "dev-master": "5.x-dev"
         }
     }
 }


### PR DESCRIPTION
Currently, we can't solve deprecations in the latest Symfony without dropping support for Symfony 3.
A solution is in progress in branch 3 of knp-components, so we need to allow it here to be able to test.

This PR is also restricting possible versions of phpunit, and allowing wider aliases for dev-master.