### PR TITLE
Allow to use array to check if pagination is sorted

### DIFF
--- a/src/Helper/Processor.php
+++ b/src/Helper/Processor.php
@@ -55,17 +55,13 @@ final class Processor
      * alias and field. $options holds all link
      * parameters like "alt, class" and so on.
      *
-     * $key example: "article.title"
+     * $key examples: "article.title" or "['article.title', 'article.subtitle']"
      *
      * @param string|array $title
-     * @param string|array $key
+     * @param string|string[] $key
      */
     public function sortable(SlidingPaginationInterface $pagination, $title, $key, array $options = [], array $params = []): array
     {
-        if (\is_array($key)) {
-            $key = \implode('+', $key);
-        }
-
         $options = \array_merge([
             'absolute' => UrlGeneratorInterface::ABSOLUTE_PATH,
             'translationParameters' => [],
@@ -79,7 +75,7 @@ final class Processor
 
         $params = \array_merge($pagination->getParams(), $params);
 
-        $direction = isset($options['defaultDirection']) ? $options['defaultDirection'] : 'asc';
+        $direction = $options['defaultDirection'] ?? 'asc';
         if (null !== $pagination->getPaginatorOption('sortDirectionParameterName')) {
             if (isset($params[$pagination->getPaginatorOption('sortDirectionParameterName')])) {
                 $direction = $params[$pagination->getPaginatorOption('sortDirectionParameterName')];
@@ -108,6 +104,10 @@ final class Processor
 
         if (\is_array($title) && \array_key_exists($direction, $title)) {
             $title = $title[$direction];
+        }
+
+        if (\is_array($key)) {
+            $key = \implode('+', $key);
         }
 
         $params = \array_merge(

--- a/src/Pagination/SlidingPagination.php
+++ b/src/Pagination/SlidingPagination.php
@@ -113,6 +113,10 @@ final class SlidingPagination extends AbstractPagination implements SlidingPagin
             return isset($params[$this->getPaginatorOption('sortFieldParameterName')]);
         }
 
+        if (\is_array($key)) {
+            $key = \implode('+', $key);
+        }
+
         return isset($params[$this->getPaginatorOption('sortFieldParameterName')]) && $params[$this->getPaginatorOption('sortFieldParameterName')] === $key;
     }
 

--- a/tests/Pagination/SlidingPaginationTest.php
+++ b/tests/Pagination/SlidingPaginationTest.php
@@ -34,6 +34,21 @@ final class SlidingPaginationTest extends TestCase
         $this->assertSame($expected, $this->pagination->getPageCount());
     }
 
+    /**
+     * @dataProvider getSortedData
+     */
+    public function testSorted(bool $expected, string $sort, string $direction, $key): void
+    {
+        $this->pagination->setPaginatorOptions([
+            'sortFieldParameterName' => 'sort',
+            'sortDirectionParameterName' => 'direction'
+        ]);
+        $this->pagination->setParam('sort', $sort);
+        $this->pagination->setParam('direction', $direction);
+
+        $this->assertSame($expected, $this->pagination->isSorted($key));
+    }
+
     public function getPageLimitData(): array
     {
         return [
@@ -42,5 +57,14 @@ final class SlidingPaginationTest extends TestCase
             'Pages limited to 3' => [3, 400, 25, 3],
             'Pages limited to 3, but limit not hit' => [2, 26, 25, 3],
         ];
+    }
+
+    public function getSortedData(): \Generator
+    {
+        yield [true, 'title', 'asc', null];
+        yield [true, 'title', 'asc', 'title'];
+        yield [true, 'title+subtitle', 'asc', 'title+subtitle'];
+        yield [true, 'title+subtitle', 'asc', ['title', 'subtitle']];
+        yield [false, 'title', 'asc', 'subtitle'];
     }
 }


### PR DESCRIPTION
This change allow to check if the pagination is sorted by using either a string or an array

```twig
{% if pagination.isSorted('article.title') %}...{% endif %}

or

{% if pagination.isSorted('article.title+article.subtitle') %}...{% endif %}

or

{% if pagination.isSorted(['article.title', 'article.subtitle')]) %}...{% endif %}

```