### PR TITLE
SlidingPagination::getPage() should return int|null

### DIFF
--- a/src/Pagination/SlidingPagination.php
+++ b/src/Pagination/SlidingPagination.php
@@ -131,7 +131,13 @@ final class SlidingPagination extends AbstractPagination implements SlidingPagin
 
     public function getPage(): ?int
     {
-        return $this->params[$this->getPaginatorOption('pageParameterName')] ?? null;
+        $param = (int) $this->params[$this->getPaginatorOption('pageParameterName')];
+
+        if (0 === $param) {
+            return null;
+        }
+
+        return $param;
     }
 
     public function getSort(): ?string

--- a/tests/Pagination/SlidingPaginationTest.php
+++ b/tests/Pagination/SlidingPaginationTest.php
@@ -20,6 +20,7 @@ final class SlidingPaginationTest extends TestCase
     protected function setUp(): void
     {
         $this->pagination = new SlidingPagination([]);
+        $this->pagination->setPaginatorOptions(['pageParameterName' => 'page']);
     }
 
     /**
@@ -32,6 +33,20 @@ final class SlidingPaginationTest extends TestCase
         $this->pagination->setPageLimit($pageLimit);
 
         $this->assertSame($expected, $this->pagination->getPageCount());
+    }
+
+    public function testPageParamWithInteger(): void
+    {
+        $this->pagination->setParam('page', 1);
+
+        $this->assertSame(1, $this->pagination->getPage());
+    }
+
+    public function testPageParamWithString(): void
+    {
+        $this->pagination->setParam('page', 'string');
+
+        $this->assertNull($this->pagination->getPage());
     }
 
     /**


### PR DESCRIPTION
I noticed some server errors in my logs, when someone calls `?page=hackattempt` the server returns the following error:

```
Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination::getPage(): Return value must be of type ?int, string returned
```

In my opinion, `SlidingPagination::getPage()` should always return `int|null` and not throw an exception if someone passes a string.