### PR TITLE
Add supported DBAL querybuilder

### DIFF
--- a/translations/KnpPaginatorBundle.ca.xliff
+++ b/translations/KnpPaginatorBundle.ca.xliff
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="ca" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="0" resname="label_previous">
+        <source>label_previous</source>
+        <target>Anterior</target>
+      </trans-unit>
+      <trans-unit id="1" resname="label_next">
+        <source>label_next</source>
+        <target>Següent</target>
+      </trans-unit>
+      <trans-unit id="2" resname="filter_searchword">
+        <source>filter_searchword</source>
+        <target>Cercar...</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
Readme doesn't mention that the DBAL querybuilder is supported, see https://github.com/KnpLabs/KnpPaginatorBundle/issues/38#issuecomment-296177064

This pull request simply documents this to the readme.