### PR TITLE
Implement/Extend Paginator generics

### DIFF
--- a/src/Helper/Processor.php
+++ b/src/Helper/Processor.php
@@ -28,9 +28,9 @@ final class Processor
     /**
      * Generates pagination template data.
      *
-     * @param SlidingPaginationInterface<mixed> $pagination
-     * @param array<string, mixed>              $queryParams
-     * @param array<string, mixed>              $viewParams
+     * @param SlidingPaginationInterface<mixed, mixed> $pagination
+     * @param array<string, mixed>                     $queryParams
+     * @param array<string, mixed>                     $viewParams
      *
      * @return array<string, mixed>
      */
@@ -57,11 +57,11 @@ final class Processor
      *
      * $key examples: "article.title" or "['article.title', 'article.subtitle']"
      *
-     * @param SlidingPaginationInterface<mixed> $pagination
-     * @param string|array<string, mixed>       $title
-     * @param string|array<string, mixed>       $key
-     * @param array<string, mixed>              $options
-     * @param array<string, mixed>              $params
+     * @param SlidingPaginationInterface<mixed, mixed> $pagination
+     * @param string|array<string, mixed>              $title
+     * @param string|array<string, mixed>              $key
+     * @param array<string, mixed>                     $options
+     * @param array<string, mixed>                     $params
      *
      * @return array<string, mixed>
      */
@@ -156,10 +156,10 @@ final class Processor
      *
      * $key example: "article.title"
      *
-     * @param SlidingPaginationInterface<mixed> $pagination
-     * @param array<string, mixed>              $fields
-     * @param array<string, mixed>              $options
-     * @param array<string, mixed>              $params
+     * @param SlidingPaginationInterface<mixed, mixed> $pagination
+     * @param array<string, mixed>                     $fields
+     * @param array<string, mixed>                     $options
+     * @param array<string, mixed>                     $params
      *
      * @return array<string, mixed>
      */

--- a/src/Pagination/SlidingPagination.php
+++ b/src/Pagination/SlidingPagination.php
@@ -4,6 +4,14 @@ namespace Knp\Bundle\PaginatorBundle\Pagination;
 
 use Knp\Component\Pager\Pagination\AbstractPagination;
 
+/**
+ * @template TKey
+ * @template TValue
+ *
+ * @template-extends AbstractPagination<TKey, TValue>
+ *
+ * @template-implements SlidingPaginationInterface<TKey, TValue>
+ */
 final class SlidingPagination extends AbstractPagination implements SlidingPaginationInterface
 {
     private ?string $route = null;

--- a/src/Pagination/SlidingPaginationInterface.php
+++ b/src/Pagination/SlidingPaginationInterface.php
@@ -4,6 +4,12 @@ namespace Knp\Bundle\PaginatorBundle\Pagination;
 
 use Knp\Component\Pager\Pagination\PaginationInterface;
 
+/**
+ * @template TKey
+ * @template TValue
+ *
+ * @template-extends PaginationInterface<TKey, TValue>
+ */
 interface SlidingPaginationInterface extends PaginationInterface
 {
     public function getRoute(): ?string;

--- a/src/Templating/PaginationHelper.php
+++ b/src/Templating/PaginationHelper.php
@@ -29,9 +29,9 @@ final class PaginationHelper extends Helper
     /**
      * Renders the pagination template.
      *
-     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed> $pagination
-     * @param array<string, mixed>                                            $queryParams
-     * @param array<string, mixed>                                            $viewParams
+     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed, mixed> $pagination
+     * @param array<string, mixed>                                                   $queryParams
+     * @param array<string, mixed>                                                   $viewParams
      */
     public function render(SlidingPaginationInterface $pagination, ?string $template = null, array $queryParams = [], array $viewParams = []): string
     {
@@ -49,10 +49,10 @@ final class PaginationHelper extends Helper
      *
      * $key example: "article.title"
      *
-     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed> $pagination
-     * @param string|array<string, mixed>                                     $key
-     * @param array<string, mixed>                                            $options
-     * @param array<string, mixed>                                            $params
+     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed, mixed> $pagination
+     * @param string|array<string, mixed>                                            $key
+     * @param array<string, mixed>                                                   $options
+     * @param array<string, mixed>                                                   $params
      */
     public function sortable(SlidingPaginationInterface $pagination, string $title, $key, array $options = [], array $params = [], ?string $template = null): string
     {
@@ -70,10 +70,10 @@ final class PaginationHelper extends Helper
      *
      * $key example: "article.title"
      *
-     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed> $pagination
-     * @param array<string, mixed>                                            $fields
-     * @param array<string, mixed>                                            $options
-     * @param array<string, mixed>                                            $params
+     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed, mixed> $pagination
+     * @param array<string, mixed>                                                   $fields
+     * @param array<string, mixed>                                                   $options
+     * @param array<string, mixed>                                                   $params
      */
     public function filter(SlidingPaginationInterface $pagination, array $fields, array $options = [], array $params = [], ?string $template = null): string
     {

--- a/src/Twig/Extension/PaginationExtension.php
+++ b/src/Twig/Extension/PaginationExtension.php
@@ -29,9 +29,9 @@ final class PaginationExtension extends AbstractExtension
     /**
      * Renders the pagination template.
      *
-     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed> $pagination
-     * @param array<string, mixed>                                            $queryParams
-     * @param array<string, mixed>                                            $viewParams
+     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed, mixed> $pagination
+     * @param array<string, mixed>                                                   $queryParams
+     * @param array<string, mixed>                                                   $viewParams
      */
     public function render(Environment $env, SlidingPaginationInterface $pagination, ?string $template = null, ?array $queryParams = [], ?array $viewParams = []): string
     {
@@ -49,10 +49,10 @@ final class PaginationExtension extends AbstractExtension
      *
      * $key example: "article.title"
      *
-     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed> $pagination
-     * @param string|array<string, mixed>                                     $key
-     * @param array<string, mixed>                                            $options
-     * @param array<string, mixed>                                            $params
+     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed, mixed> $pagination
+     * @param string|array<string, mixed>                                            $key
+     * @param array<string, mixed>                                                   $options
+     * @param array<string, mixed>                                                   $params
      */
     public function sortable(Environment $env, SlidingPaginationInterface $pagination, string $title, $key, array $options = [], array $params = [], ?string $template = null): string
     {
@@ -70,10 +70,10 @@ final class PaginationExtension extends AbstractExtension
      *
      * $key example: "article.title"
      *
-     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed> $pagination
-     * @param array<string, mixed>                                            $fields
-     * @param array<string, mixed>                                            $options
-     * @param array<string, mixed>|null                                       $params
+     * @param \Knp\Bundle\PaginatorBundle\Pagination\SlidingPagination<mixed, mixed> $pagination
+     * @param array<string, mixed>                                                   $fields
+     * @param array<string, mixed>                                                   $options
+     * @param array<string, mixed>|null                                              $params
      */
     public function filter(Environment $env, SlidingPaginationInterface $pagination, array $fields, ?array $options = [], ?array $params = [], ?string $template = null): string
     {


### PR DESCRIPTION
@template-extends and @template-implements were missing since they were added to the knp-components package.