### PR TITLE
Test Symfony v6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,20 +18,21 @@
     "require": {
         "php": "^8.0",
         "knplabs/knp-components": "^4.1",
-        "symfony/config": "^6.0",
-        "symfony/dependency-injection": "^6.0",
-        "symfony/event-dispatcher": "^6.0",
-        "symfony/http-foundation": "^6.0",
-        "symfony/http-kernel": "^6.0",
-        "symfony/routing": "^6.0",
-        "symfony/translation": "^6.0",
+        "symfony/config": "6.4.x-dev as 6.4.0",
+        "symfony/dependency-injection": "6.4.x-dev as 6.4.0",
+        "symfony/event-dispatcher": "6.4.x-dev as 6.4.0",
+        "symfony/http-foundation": "6.4.x-dev as 6.4.0",
+        "symfony/http-kernel": "6.4.x-dev as 6.4.0",
+        "symfony/error-handler": "6.4.x-dev as 6.4.0",
+        "symfony/routing": "6.4.x-dev as 6.4.0",
+        "symfony/translation": "6.4.x-dev as 6.4.0",
         "twig/twig": "^3.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "^9.5",
-        "symfony/expression-language": "^6.0",
-        "symfony/templating": "^6.0"
+        "symfony/expression-language": "6.4.x-dev as 6.4.0",
+        "symfony/templating": "6.4.x-dev as 6.4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Help test Symfony 6.4: https://github.com/symfony/symfony/issues/51563

> root@112e7e8a1018:/var/www/html# SYMFONY_PATCH_TYPE_DECLARATIONS=force=1 ./vendor/bin/patch-type-declarations
 (3)
Since symfony/templating 6.4: "Symfony\Component\Templating\Helper\Helper" is deprecated since version 6.4 and will be removed in 7.0. Use Twig instead.
Since symfony/templating 6.4: "Symfony\Component\Templating\Helper\HelperInterface" is deprecated since version 6.4 and will be removed in 7.0. Use Twig instead.
The "Knp\Bundle\PaginatorBundle\Templating\PaginationHelper" class extends "Symfony\Component\Templating\Helper\Helper" that is deprecated since Symfony 6.4, use Twig instead.

The only issue is in `Knp\Bundle\PaginatorBundle\Templating\PaginationHelper` in order to be compatible with 7.x

Do you think, deprecating this service is the way ? (I didn't find documentation for this part)

