### PR TITLE
Documentation update: make YAML configuratoin file explanation more simple

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ public function registerBundles()
 
 ### Configuration example
 
-You can configure default query parameter names and templates
+You can configure default query parameter names and templates.
+
+You need to create a file "config/packages/knp_paginator.yaml". The file extension must be "yaml" and not "yml".
 
 #### YAML:
 ```yaml


### PR DESCRIPTION
I just spend an hour to find how to name my configuration file.

[This comment](https://stackoverflow.com/a/74288682/7186622) saved my day, so I just wanted to make the documentation more clear.