### PR TITLE
docs: update bootstrap v5 template filename

### DIFF
--- a/docs/paginator_configuration.md
+++ b/docs/paginator_configuration.md
@@ -26,7 +26,7 @@ knp_paginator:
 There are a few additional pagination templates, that could be used out of the box in `knp_paginator.template.pagination` key:
 
 * `@KnpPaginator/Pagination/sliding.html.twig` (by default)
-* `@KnpPaginator/Pagination/twitter_bootstrap_v5_pagination.html.twig`
+* `@KnpPaginator/Pagination/bootstrap_v5_pagination.html.twig`
 * `@KnpPaginator/Pagination/twitter_bootstrap_v4_pagination.html.twig`
 * `@KnpPaginator/Pagination/foundation_v6_pagination.html.twig`
 * `@KnpPaginator/Pagination/foundation_v5_pagination.html.twig`


### PR DESCRIPTION
`twitter_bootstrap_v5_pagination.html.twig` doesn't seem to exist anymore, and was apparently replaced by `bootstrap_v5_pagination.html.twig`