### PR TITLE
doc: fix PHP conf in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ return static function (ContainerConfigurator $configurator): void
         ],
         'template' => [
             'pagination' => '@KnpPaginator/Pagination/sliding.html.twig',     // sliding pagination controls template
-            'pagination' => '@KnpPaginator/Pagination/rel_links.html.twig',     // <link rel=...> tags template
+            'rel_links' => '@KnpPaginator/Pagination/rel_links.html.twig',     // <link rel=...> tags template
             'sortable' => '@KnpPaginator/Pagination/sortable_link.html.twig', // sort link template
             'filtration' => '@KnpPaginator/Pagination/filtration.html.twig'   // filters template
         ]


### PR DESCRIPTION
YAML and PHP examples were inconsistent: https://github.com/KnpLabs/KnpPaginatorBundle/blob/f2348da858517856004cd024b380d3446fae90dc/README.md#configuration-example