### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Generally this bundle is based on [Knp Pager component][knp_component_pager]. Th
 component introduces a different way of pagination handling. You can read more about the
 internal logic on the given documentation link.
 
-[![knpbundles.com](http://knpbundles.com/KnpLabs/KnpPaginatorBundle/badge-short)](http://knpbundles.com/KnpLabs/KnpPaginatorBundle)
-
 **Note:** Keep **knp-components** in sync with this bundle. If you want to use
 older version of KnpPaginatorBundle - use **v3.0** or **v4.X** tags in the repository which is
 suitable to paginate **ODM MongoDB** and **ORM 2.0** queries

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ suitable to paginate **ODM MongoDB** and **ORM 2.0** queries
 
 ## Latest updates
 
-For notes about the latest changes please read [`CHANGELOG`](https://github.com/KnpLabs/KnpPaginatorBundle/blob/master/CHANGELOG.md),
-for required changes in your code please read [`UPGRADE`](https://github.com/KnpLabs/KnpPaginatorBundle/blob/master/docs/upgrade.md)
-chapter of the documentation.
+For details regarding changes please read about the [releases](https://github.com/KnpLabs/KnpPaginatorBundle/releases).
 
 ## Requirements:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ conflicting parameters.
 
 ## Installation and configuration:
 
-### Pretty simple with [Composer](http://packagist.org), run
+### Pretty simple with [Composer](https://packagist.org), run
 
 ```sh
 composer require knplabs/knp-paginator-bundle

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ knp_paginator:
         filter_value_name: filterValue  # filter value query parameter name
     template:
         pagination: '@KnpPaginator/Pagination/sliding.html.twig'     # sliding pagination controls template
-        rel_links: '@KnpPaginator/Pagination/rel_links.html.twig'     # <link rel=...> tags template
+        rel_links: '@KnpPaginator/Pagination/rel_links.html.twig'    # <link rel=...> tags template
         sortable: '@KnpPaginator/Pagination/sortable_link.html.twig' # sort link template
         filtration: '@KnpPaginator/Pagination/filtration.html.twig'  # filters template
 ```
@@ -105,13 +105,13 @@ return static function (ContainerConfigurator $configurator): void
             'sort_direction_name' => 'direction', // sort direction query parameter name
             'distinct' => true,                   // ensure distinct results, useful when ORM queries are using GROUP BY statements
             'filter_field_name' => 'filterField', // filter field query parameter name
-            'filter_value_name' => 'filterValue'  // filter value query parameter name
+            'filter_value_name' => 'filterValue', // filter value query parameter name
         ],
         'template' => [
             'pagination' => '@KnpPaginator/Pagination/sliding.html.twig',     // sliding pagination controls template
-            'rel_links' => '@KnpPaginator/Pagination/rel_links.html.twig',     // <link rel=...> tags template
+            'rel_links' => '@KnpPaginator/Pagination/rel_links.html.twig',    // <link rel=...> tags template
             'sortable' => '@KnpPaginator/Pagination/sortable_link.html.twig', // sort link template
-            'filtration' => '@KnpPaginator/Pagination/filtration.html.twig'   // filters template
+            'filtration' => '@KnpPaginator/Pagination/filtration.html.twig',  // filters template
         ]
     ]);
 };
@@ -186,8 +186,8 @@ public function listAction(EntityManagerInterface $em, PaginatorInterface $pagin
 
     $pagination = $paginator->paginate(
         $query, /* query NOT result */
-        $request->query->getInt('page', 1), /*page number*/
-        10 /*limit per page*/
+        $request->query->getInt('page', 1), /* page number */
+        10 /* limit per page */
     );
 
     // parameters to template

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ conflicting parameters.
 ## More detailed documentation:
 
 - Creating [custom pagination subscribers][doc_custom_pagination_subscriber]
-- [Extending pagination](#) class (todo, may require some refactoring)
 - [Customizing view][doc_templates] templates and arguments
 
 ## Installation and configuration:

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ return static function (ContainerConfigurator $configurator): void
             'sort_direction_name' => 'direction', // sort direction query parameter name
             'distinct' => true,                   // ensure distinct results, useful when ORM queries are using GROUP BY statements
             'filter_field_name' => 'filterField', // filter field query parameter name
-            'filter_value_name' => 'filterValue', // filter value query parameter name
+            'filter_value_name' => 'filterValue'  // filter value query parameter name
         ],
         'template' => [
             'pagination' => '@KnpPaginator/Pagination/sliding.html.twig',     // sliding pagination controls template
             'rel_links' => '@KnpPaginator/Pagination/rel_links.html.twig',    // <link rel=...> tags template
             'sortable' => '@KnpPaginator/Pagination/sortable_link.html.twig', // sort link template
-            'filtration' => '@KnpPaginator/Pagination/filtration.html.twig',  // filters template
+            'filtration' => '@KnpPaginator/Pagination/filtration.html.twig'   // filters template
         ]
     ]);
 };


### PR DESCRIPTION
- Fixes #811 by replacing broken links with working link to releases page
- Removes link to nonexistent documentation for extending
- Uses https for composer link
- Formats and aligns some comments
- Fixes #798 by removing dead link (and formerly badge) to http://knpbundles.com/KnpLabs/KnpPaginatorBundle
