### PR TITLE
[BUGFIX] Wrong target language used for simplified Chinese

### DIFF
--- a/translations/KnpPaginatorBundle.zh_CN.xliff
+++ b/translations/KnpPaginatorBundle.zh_CN.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="zh_CN" datatype="plaintext" original="file.ext">
+  <file source-language="en" target-language="zh-CN" datatype="plaintext" original="file.ext">
     <body>
       <trans-unit id="0" resname="label_previous">
         <source>label_previous</source>


### PR DESCRIPTION
Last week the translation file for simplified Chinese has been added through commit https://github.com/KnpLabs/KnpPaginatorBundle/commit/92002cc51dba8e4c5a0403f390b5814e8bd50192

Unfortunately, it got assigned the wrong value for the `target-language` attribute. The Symfony XliffUtils helper class now complains [when validating the schema](https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Translation/Loader/XliffFileLoader.php#L61).

```log
Invalid resource provided: "/var/www/html/vendor/knplabs/knp-paginator-bundle/translations/KnpPaginatorBundle.zh_CN.xliff"; Errors: [ERROR 1824] Element '{urn:oasis:names:tc:xliff:document:1.2}file', attribute 'target-language': 'zh_CN' is not a valid value of the atomic type 'xs:language'.
```

See the following resources:
- [https://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#target-language](https://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#target-language)
- [https://www.w3.org/TR/REC-xml/#sec-lang-tag](https://www.w3.org/TR/REC-xml/#sec-lang-tag)

This PR fixes that circumstance by changing the value from `zh_CN` to `zh-CN`.