### PR TITLE
Page parameter name

### DIFF
--- a/src/Helper/Processor.php
+++ b/src/Helper/Processor.php
@@ -36,7 +36,7 @@ final class Processor
 
         $data['route'] = $pagination->getRoute();
         $data['query'] = \array_merge($pagination->getParams(), $queryParams);
-        $data['paginatorOptions'] = $pagination->getPaginatorOptions();
+        $data['options'] = $pagination->getPaginatorOptions();
 
         return \array_merge(
             $pagination->getPaginatorOptions() ?? [], // options given to paginator when paginated

--- a/src/Helper/Processor.php
+++ b/src/Helper/Processor.php
@@ -36,6 +36,7 @@ final class Processor
 
         $data['route'] = $pagination->getRoute();
         $data['query'] = \array_merge($pagination->getParams(), $queryParams);
+        $data['pagination'] = $pagination;
 
         return \array_merge(
             $pagination->getPaginatorOptions() ?? [], // options given to paginator when paginated

--- a/src/Helper/Processor.php
+++ b/src/Helper/Processor.php
@@ -36,7 +36,7 @@ final class Processor
 
         $data['route'] = $pagination->getRoute();
         $data['query'] = \array_merge($pagination->getParams(), $queryParams);
-        $data['pagination'] = $pagination;
+        $data['paginatorOptions'] = $pagination->getPaginatorOptions();
 
         return \array_merge(
             $pagination->getPaginatorOptions() ?? [], // options given to paginator when paginated

--- a/src/Twig/Extension/PaginationRuntime.php
+++ b/src/Twig/Extension/PaginationRuntime.php
@@ -113,16 +113,17 @@ final class PaginationRuntime implements RuntimeExtensionInterface
      * @param int $page
      * @return array<string, mixed>
      */
-    public function getQueryParams(array $query, int $page): array
+    public function getQueryParams(array $query, int $page, ?SlidingPaginationInterface $pagination = null): array
     {
+        $pageName = $pagination?->getPaginatorOption('pageParameterName') ?? $this->pageName;
         if ($page === 1 && $this->skipFirstPageLink) {
-            if (isset($query[$this->pageName])) {
-                unset($query[$this->pageName]);
+            if (isset($query[$pageName])) {
+                unset($query[$pageName]);
             }
 
             return $query;
         }
 
-        return array_merge($query, [$this->pageName => $page]);
+        return array_merge($query, [$pageName => $page]);
     }
 }

--- a/src/Twig/Extension/PaginationRuntime.php
+++ b/src/Twig/Extension/PaginationRuntime.php
@@ -116,7 +116,11 @@ final class PaginationRuntime implements RuntimeExtensionInterface
      */
     public function getQueryParams(array $query, int $page, array $options): array
     {
-        $pageName = $options['pageParameterName'] ?? $this->pageName;
+        $pageName = $this->pageName;
+        if (isset($options['pageParameterName']) && is_string($options['pageParameterName'])) {
+            $pageName = $options['pageParameterName'];
+        }
+
         if ($page === 1 && $this->skipFirstPageLink) {
             if (isset($query[$pageName])) {
                 unset($query[$pageName]);

--- a/src/Twig/Extension/PaginationRuntime.php
+++ b/src/Twig/Extension/PaginationRuntime.php
@@ -111,12 +111,12 @@ final class PaginationRuntime implements RuntimeExtensionInterface
     /**
      * @param array<string, mixed>      $query
      * @param int                       $page
-     * @param array<string, mixed>|null $paginatorOptions
+     * @param array<string, mixed>      $options
      * @return array<string, mixed>
      */
-    public function getQueryParams(array $query, int $page, ?array $paginatorOptions = []): array
+    public function getQueryParams(array $query, int $page, array $options): array
     {
-        $pageName = $paginatorOptions['pageParameterName'] ?? $this->pageName;
+        $pageName = $options['pageParameterName'] ?? $this->pageName;
         if ($page === 1 && $this->skipFirstPageLink) {
             if (isset($query[$pageName])) {
                 unset($query[$pageName]);

--- a/src/Twig/Extension/PaginationRuntime.php
+++ b/src/Twig/Extension/PaginationRuntime.php
@@ -109,13 +109,14 @@ final class PaginationRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * @param array<string, mixed> $query
-     * @param int $page
+     * @param array<string, mixed>      $query
+     * @param int                       $page
+     * @param array<string, mixed>|null $paginatorOptions
      * @return array<string, mixed>
      */
-    public function getQueryParams(array $query, int $page, ?SlidingPaginationInterface $pagination = null): array
+    public function getQueryParams(array $query, int $page, ?array $paginatorOptions = []): array
     {
-        $pageName = $pagination?->getPaginatorOption('pageParameterName') ?? $this->pageName;
+        $pageName = $paginatorOptions['pageParameterName'] ?? $this->pageName;
         if ($page === 1 && $this->skipFirstPageLink) {
             if (isset($query[$pageName])) {
                 unset($query[$pageName]);

--- a/templates/Pagination/bulma_pagination.html.twig
+++ b/templates/Pagination/bulma_pagination.html.twig
@@ -13,13 +13,13 @@
 {% if pageCount > 1 %}
     <nav class="{{ classes|join(' ') }}" role="navigation" aria-label="pagination">
         {% if previous is defined %}
-            <a rel="prev" class="pagination-previous" href="{{ path(route, knp_pagination_query(query, previous)) }}">{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+            <a rel="prev" class="pagination-previous" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% else %}
             <a class="pagination-previous" disabled>{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% endif %}
 
         {% if next is defined %}
-            <a rel="next" class="pagination-next" href="{{ path(route, knp_pagination_query(query, next)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
+            <a rel="next" class="pagination-next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% else %}
             <a class="pagination-next" disabled>{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% endif %}
@@ -27,9 +27,9 @@
         <ul class="pagination-list">
             <li>
                 {% if current == first %}
-                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, first)) }}">1</a>
+                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">1</a>
                 {% else %}
-                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, first)) }}">1</a>
+                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">1</a>
                 {% endif %}
             </li>
 
@@ -43,9 +43,9 @@
                 {% if first != page and page != last %}
                     <li>
                         {% if page == current %}
-                            <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, page)) }}">{{ page }}</a>
+                            <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
                         {% else %}
-                            <a class="pagination-link" aria-label="Goto page {{ page }}" href="{{ path(route, knp_pagination_query(query, page)) }}">{{ page }}</a>
+                            <a class="pagination-link" aria-label="Goto page {{ page }}" href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
                         {% endif %}
                     </li>
                 {% endif %}
@@ -59,9 +59,9 @@
 
             <li>
                 {% if current == last %}
-                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, last)) }}">{{ last }}</a>
+                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">{{ last }}</a>
                 {% else %}
-                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, last)) }}">{{ last }}</a>
+                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">{{ last }}</a>
                 {% endif %}
             </li>
         </ul>

--- a/templates/Pagination/bulma_pagination.html.twig
+++ b/templates/Pagination/bulma_pagination.html.twig
@@ -13,13 +13,13 @@
 {% if pageCount > 1 %}
     <nav class="{{ classes|join(' ') }}" role="navigation" aria-label="pagination">
         {% if previous is defined %}
-            <a rel="prev" class="pagination-previous" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+            <a rel="prev" class="pagination-previous" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% else %}
             <a class="pagination-previous" disabled>{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% endif %}
 
         {% if next is defined %}
-            <a rel="next" class="pagination-next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
+            <a rel="next" class="pagination-next" href="{{ path(route, knp_pagination_query(query, next, options)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% else %}
             <a class="pagination-next" disabled>{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% endif %}
@@ -27,9 +27,9 @@
         <ul class="pagination-list">
             <li>
                 {% if current == first %}
-                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">1</a>
+                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, first, options)) }}">1</a>
                 {% else %}
-                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">1</a>
+                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, first, options)) }}">1</a>
                 {% endif %}
             </li>
 
@@ -43,9 +43,9 @@
                 {% if first != page and page != last %}
                     <li>
                         {% if page == current %}
-                            <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
+                            <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, page, options)) }}">{{ page }}</a>
                         {% else %}
-                            <a class="pagination-link" aria-label="Goto page {{ page }}" href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
+                            <a class="pagination-link" aria-label="Goto page {{ page }}" href="{{ path(route, knp_pagination_query(query, page, options)) }}">{{ page }}</a>
                         {% endif %}
                     </li>
                 {% endif %}
@@ -59,9 +59,9 @@
 
             <li>
                 {% if current == last %}
-                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">{{ last }}</a>
+                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, last, options)) }}">{{ last }}</a>
                 {% else %}
-                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">{{ last }}</a>
+                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, last, options)) }}">{{ last }}</a>
                 {% endif %}
             </li>
         </ul>

--- a/templates/Pagination/bulma_pagination.html.twig
+++ b/templates/Pagination/bulma_pagination.html.twig
@@ -13,13 +13,13 @@
 {% if pageCount > 1 %}
     <nav class="{{ classes|join(' ') }}" role="navigation" aria-label="pagination">
         {% if previous is defined %}
-            <a rel="prev" class="pagination-previous" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+            <a rel="prev" class="pagination-previous" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% else %}
             <a class="pagination-previous" disabled>{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% endif %}
 
         {% if next is defined %}
-            <a rel="next" class="pagination-next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
+            <a rel="next" class="pagination-next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% else %}
             <a class="pagination-next" disabled>{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}</a>
         {% endif %}
@@ -27,9 +27,9 @@
         <ul class="pagination-list">
             <li>
                 {% if current == first %}
-                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">1</a>
+                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">1</a>
                 {% else %}
-                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">1</a>
+                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">1</a>
                 {% endif %}
             </li>
 
@@ -43,9 +43,9 @@
                 {% if first != page and page != last %}
                     <li>
                         {% if page == current %}
-                            <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
+                            <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
                         {% else %}
-                            <a class="pagination-link" aria-label="Goto page {{ page }}" href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
+                            <a class="pagination-link" aria-label="Goto page {{ page }}" href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
                         {% endif %}
                     </li>
                 {% endif %}
@@ -59,9 +59,9 @@
 
             <li>
                 {% if current == last %}
-                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">{{ last }}</a>
+                    <a class="pagination-link is-current" aria-label="Page {{ current }}" aria-current="page" href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">{{ last }}</a>
                 {% else %}
-                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">{{ last }}</a>
+                    <a class="pagination-link" href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">{{ last }}</a>
                 {% endif %}
             </li>
         </ul>

--- a/templates/Pagination/foundation_v5_pagination.html.twig
+++ b/templates/Pagination/foundation_v5_pagination.html.twig
@@ -21,7 +21,7 @@
     <ul class="pagination">
         {% if previous is defined %}
                  <li class="arrow">
-                     <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">&laquo; {{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+                     <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">&laquo; {{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
                  </li>
         {% else %}
             <li class="arrow unavailable">
@@ -33,11 +33,11 @@
 
         {% if startPage > 1 %}
             <li>
-                <a href="{{ path(route, knp_pagination_query(query, 1, pagination)) }}">1</a>
+                <a href="{{ path(route, knp_pagination_query(query, 1, paginatorOptions)) }}">1</a>
             </li>
             {% if startPage == 3 %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, 2, pagination)) }}">2</a>
+                    <a href="{{ path(route, knp_pagination_query(query, 2, paginatorOptions)) }}">2</a>
                 </li>
             {% elseif startPage != 2 %}
                 <li class="unavailable">
@@ -49,7 +49,7 @@
         {% for page in pagesInRange %}
             {% if page != current %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">
+                    <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">
                         {{ page }}
                     </a>
                 </li>
@@ -69,20 +69,20 @@
                     </li>
                 {% else %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), pagination)) }}">
+                        <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), paginatorOptions)) }}">
                             {{ pageCount - 1 }}
                         </a>
                     </li>
                 {% endif %}
             {% endif %}
             <li>
-                <a href="{{ path(route, knp_pagination_query(query, pageCount, pagination)) }}">{{ pageCount }}</a>
+                <a href="{{ path(route, knp_pagination_query(query, pageCount, paginatorOptions)) }}">{{ pageCount }}</a>
             </li>
         {% endif %}
 
         {% if next is defined %}
             <li class="arrow">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">
                     {{ 'label_next'|trans({}, 'KnpPaginatorBundle') }} &nbsp;&raquo;
                 </a>
             </li>

--- a/templates/Pagination/foundation_v5_pagination.html.twig
+++ b/templates/Pagination/foundation_v5_pagination.html.twig
@@ -21,7 +21,7 @@
     <ul class="pagination">
         {% if previous is defined %}
                  <li class="arrow">
-                     <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous)) }}">&laquo; {{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+                     <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">&laquo; {{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
                  </li>
         {% else %}
             <li class="arrow unavailable">
@@ -33,11 +33,11 @@
 
         {% if startPage > 1 %}
             <li>
-                <a href="{{ path(route, knp_pagination_query(query, 1)) }}">1</a>
+                <a href="{{ path(route, knp_pagination_query(query, 1, pagination)) }}">1</a>
             </li>
             {% if startPage == 3 %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, 2)) }}">2</a>
+                    <a href="{{ path(route, knp_pagination_query(query, 2, pagination)) }}">2</a>
                 </li>
             {% elseif startPage != 2 %}
                 <li class="unavailable">
@@ -49,7 +49,7 @@
         {% for page in pagesInRange %}
             {% if page != current %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, page)) }}">
+                    <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">
                         {{ page }}
                     </a>
                 </li>
@@ -69,20 +69,20 @@
                     </li>
                 {% else %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1))) }}">
+                        <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), pagination)) }}">
                             {{ pageCount - 1 }}
                         </a>
                     </li>
                 {% endif %}
             {% endif %}
             <li>
-                <a href="{{ path(route, knp_pagination_query(query, pageCount)) }}">{{ pageCount }}</a>
+                <a href="{{ path(route, knp_pagination_query(query, pageCount, pagination)) }}">{{ pageCount }}</a>
             </li>
         {% endif %}
 
         {% if next is defined %}
             <li class="arrow">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next)) }}">
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">
                     {{ 'label_next'|trans({}, 'KnpPaginatorBundle') }} &nbsp;&raquo;
                 </a>
             </li>

--- a/templates/Pagination/foundation_v5_pagination.html.twig
+++ b/templates/Pagination/foundation_v5_pagination.html.twig
@@ -21,7 +21,7 @@
     <ul class="pagination">
         {% if previous is defined %}
                  <li class="arrow">
-                     <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">&laquo; {{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+                     <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">&laquo; {{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
                  </li>
         {% else %}
             <li class="arrow unavailable">
@@ -33,11 +33,11 @@
 
         {% if startPage > 1 %}
             <li>
-                <a href="{{ path(route, knp_pagination_query(query, 1, paginatorOptions)) }}">1</a>
+                <a href="{{ path(route, knp_pagination_query(query, 1, options)) }}">1</a>
             </li>
             {% if startPage == 3 %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, 2, paginatorOptions)) }}">2</a>
+                    <a href="{{ path(route, knp_pagination_query(query, 2, options)) }}">2</a>
                 </li>
             {% elseif startPage != 2 %}
                 <li class="unavailable">
@@ -49,7 +49,7 @@
         {% for page in pagesInRange %}
             {% if page != current %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">
+                    <a href="{{ path(route, knp_pagination_query(query, page, options)) }}">
                         {{ page }}
                     </a>
                 </li>
@@ -69,20 +69,20 @@
                     </li>
                 {% else %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), paginatorOptions)) }}">
+                        <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), options)) }}">
                             {{ pageCount - 1 }}
                         </a>
                     </li>
                 {% endif %}
             {% endif %}
             <li>
-                <a href="{{ path(route, knp_pagination_query(query, pageCount, paginatorOptions)) }}">{{ pageCount }}</a>
+                <a href="{{ path(route, knp_pagination_query(query, pageCount, options)) }}">{{ pageCount }}</a>
             </li>
         {% endif %}
 
         {% if next is defined %}
             <li class="arrow">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, options)) }}">
                     {{ 'label_next'|trans({}, 'KnpPaginatorBundle') }} &nbsp;&raquo;
                 </a>
             </li>

--- a/templates/Pagination/foundation_v6_pagination.html.twig
+++ b/templates/Pagination/foundation_v6_pagination.html.twig
@@ -5,7 +5,7 @@
 
             {% if previous is defined %}
                 <li class="pagination-previous">
-                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous)) }}">
+                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">
                         {{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}
                     </a>
                 </li>
@@ -17,11 +17,11 @@
 
             {% if startPage > 1 %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, 1)) }}">1</a>
+                    <a href="{{ path(route, knp_pagination_query(query, 1, pagination)) }}">1</a>
                 </li>
                 {% if startPage == 3 %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, 2)) }}">2</a>
+                        <a href="{{ path(route, knp_pagination_query(query, 2, pagination)) }}">2</a>
                     </li>
                 {% elseif startPage != 2 %}
                     <li class="ellipsis"></li>
@@ -31,7 +31,7 @@
             {% for page in pagesInRange %}
                 {% if page != current %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, page)) }}">
+                        <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">
                             {{ page }}
                         </a>
                     </li>
@@ -46,20 +46,20 @@
                         <li class="ellipsis"></li>
                     {% else %}
                         <li>
-                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1))) }}">
+                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), pagination)) }}">
                                 {{ pageCount - 1 }}
                             </a>
                         </li>
                     {% endif %}
                 {% endif %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, pageCount)) }}">{{ pageCount }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, pageCount, pagination)) }}">{{ pageCount }}</a>
                 </li>
             {% endif %}
 
             {% if next is defined %}
                 <li class="pagination-next">
-                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next)) }}">
+                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">
                         {{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}
                     </a>
                 </li>

--- a/templates/Pagination/foundation_v6_pagination.html.twig
+++ b/templates/Pagination/foundation_v6_pagination.html.twig
@@ -5,7 +5,7 @@
 
             {% if previous is defined %}
                 <li class="pagination-previous">
-                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">
+                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">
                         {{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}
                     </a>
                 </li>
@@ -17,11 +17,11 @@
 
             {% if startPage > 1 %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, 1, paginatorOptions)) }}">1</a>
+                    <a href="{{ path(route, knp_pagination_query(query, 1, options)) }}">1</a>
                 </li>
                 {% if startPage == 3 %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, 2, paginatorOptions)) }}">2</a>
+                        <a href="{{ path(route, knp_pagination_query(query, 2, options)) }}">2</a>
                     </li>
                 {% elseif startPage != 2 %}
                     <li class="ellipsis"></li>
@@ -31,7 +31,7 @@
             {% for page in pagesInRange %}
                 {% if page != current %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">
+                        <a href="{{ path(route, knp_pagination_query(query, page, options)) }}">
                             {{ page }}
                         </a>
                     </li>
@@ -46,20 +46,20 @@
                         <li class="ellipsis"></li>
                     {% else %}
                         <li>
-                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), paginatorOptions)) }}">
+                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), options)) }}">
                                 {{ pageCount - 1 }}
                             </a>
                         </li>
                     {% endif %}
                 {% endif %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, pageCount, paginatorOptions)) }}">{{ pageCount }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, pageCount, options)) }}">{{ pageCount }}</a>
                 </li>
             {% endif %}
 
             {% if next is defined %}
                 <li class="pagination-next">
-                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">
+                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next, options)) }}">
                         {{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}
                     </a>
                 </li>

--- a/templates/Pagination/foundation_v6_pagination.html.twig
+++ b/templates/Pagination/foundation_v6_pagination.html.twig
@@ -5,7 +5,7 @@
 
             {% if previous is defined %}
                 <li class="pagination-previous">
-                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">
+                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">
                         {{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}
                     </a>
                 </li>
@@ -17,11 +17,11 @@
 
             {% if startPage > 1 %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, 1, pagination)) }}">1</a>
+                    <a href="{{ path(route, knp_pagination_query(query, 1, paginatorOptions)) }}">1</a>
                 </li>
                 {% if startPage == 3 %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, 2, pagination)) }}">2</a>
+                        <a href="{{ path(route, knp_pagination_query(query, 2, paginatorOptions)) }}">2</a>
                     </li>
                 {% elseif startPage != 2 %}
                     <li class="ellipsis"></li>
@@ -31,7 +31,7 @@
             {% for page in pagesInRange %}
                 {% if page != current %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">
+                        <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">
                             {{ page }}
                         </a>
                     </li>
@@ -46,20 +46,20 @@
                         <li class="ellipsis"></li>
                     {% else %}
                         <li>
-                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), pagination)) }}">
+                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), paginatorOptions)) }}">
                                 {{ pageCount - 1 }}
                             </a>
                         </li>
                     {% endif %}
                 {% endif %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, pageCount, pagination)) }}">{{ pageCount }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, pageCount, paginatorOptions)) }}">{{ pageCount }}</a>
                 </li>
             {% endif %}
 
             {% if next is defined %}
                 <li class="pagination-next">
-                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">
+                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">
                         {{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}
                     </a>
                 </li>

--- a/templates/Pagination/materialize_pagination.html.twig
+++ b/templates/Pagination/materialize_pagination.html.twig
@@ -14,7 +14,7 @@
     <ul class="pagination">
         {% if first is defined and current != first %}
             <li class="waves-effect">
-                <a href="{{ path(route, knp_pagination_query(query, first)) }}">
+                <a href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">
                     <i class="material-icons">first_page</i>
                 </a>
             </li>
@@ -28,7 +28,7 @@
 
         {% if previous is defined %}
             <li class="waves-effect">
-                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous)) }}">
+                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">
                     <i class="material-icons">chevron_left</i>
                 </a>
             </li>
@@ -43,7 +43,7 @@
         {% for page in pagesInRange %}
             {% if page != current %}
                 <li class="waves-effect">
-                    <a href="{{ path(route, knp_pagination_query(query, page)) }}">{{ page }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
                 </li>
             {% else %}
                 <li class="active">
@@ -54,7 +54,7 @@
 
         {% if next is defined %}
             <li class="waves-effect">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next)) }}">
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">
                     <i class="material-icons">chevron_right</i>
                 </a>
             </li>
@@ -68,7 +68,7 @@
 
         {% if last is defined and current != last %}
             <li class="waves-effect">
-                <a href="{{ path(route, knp_pagination_query(query, last)) }}">
+                <a href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">
                     <i class="material-icons">last_page</i>
                 </a>
             </li>

--- a/templates/Pagination/materialize_pagination.html.twig
+++ b/templates/Pagination/materialize_pagination.html.twig
@@ -14,7 +14,7 @@
     <ul class="pagination">
         {% if first is defined and current != first %}
             <li class="waves-effect">
-                <a href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">
+                <a href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">
                     <i class="material-icons">first_page</i>
                 </a>
             </li>
@@ -28,7 +28,7 @@
 
         {% if previous is defined %}
             <li class="waves-effect">
-                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">
+                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">
                     <i class="material-icons">chevron_left</i>
                 </a>
             </li>
@@ -43,7 +43,7 @@
         {% for page in pagesInRange %}
             {% if page != current %}
                 <li class="waves-effect">
-                    <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
                 </li>
             {% else %}
                 <li class="active">
@@ -54,7 +54,7 @@
 
         {% if next is defined %}
             <li class="waves-effect">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">
                     <i class="material-icons">chevron_right</i>
                 </a>
             </li>
@@ -68,7 +68,7 @@
 
         {% if last is defined and current != last %}
             <li class="waves-effect">
-                <a href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">
+                <a href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">
                     <i class="material-icons">last_page</i>
                 </a>
             </li>

--- a/templates/Pagination/materialize_pagination.html.twig
+++ b/templates/Pagination/materialize_pagination.html.twig
@@ -14,7 +14,7 @@
     <ul class="pagination">
         {% if first is defined and current != first %}
             <li class="waves-effect">
-                <a href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">
+                <a href="{{ path(route, knp_pagination_query(query, first, options)) }}">
                     <i class="material-icons">first_page</i>
                 </a>
             </li>
@@ -28,7 +28,7 @@
 
         {% if previous is defined %}
             <li class="waves-effect">
-                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">
+                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">
                     <i class="material-icons">chevron_left</i>
                 </a>
             </li>
@@ -43,7 +43,7 @@
         {% for page in pagesInRange %}
             {% if page != current %}
                 <li class="waves-effect">
-                    <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, page, options)) }}">{{ page }}</a>
                 </li>
             {% else %}
                 <li class="active">
@@ -54,7 +54,7 @@
 
         {% if next is defined %}
             <li class="waves-effect">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, options)) }}">
                     <i class="material-icons">chevron_right</i>
                 </a>
             </li>
@@ -68,7 +68,7 @@
 
         {% if last is defined and current != last %}
             <li class="waves-effect">
-                <a href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">
+                <a href="{{ path(route, knp_pagination_query(query, last, options)) }}">
                     <i class="material-icons">last_page</i>
                 </a>
             </li>

--- a/templates/Pagination/rel_links.html.twig
+++ b/templates/Pagination/rel_links.html.twig
@@ -1,9 +1,9 @@
 {% if pageCount > 1 %}
     {% if previous is defined %}
-        <link rel="prev" href="{{ path(route, knp_pagination_query(query, previous)) }}" />
+        <link rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}" />
     {% endif %}
 
     {% if next is defined %}
-        <link rel="next" href="{{ path(route, knp_pagination_query(query, next)) }}" />
+        <link rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}" />
     {% endif %}
 {% endif %}

--- a/templates/Pagination/rel_links.html.twig
+++ b/templates/Pagination/rel_links.html.twig
@@ -1,9 +1,9 @@
 {% if pageCount > 1 %}
     {% if previous is defined %}
-        <link rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}" />
+        <link rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}" />
     {% endif %}
 
     {% if next is defined %}
-        <link rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}" />
+        <link rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}" />
     {% endif %}
 {% endif %}

--- a/templates/Pagination/rel_links.html.twig
+++ b/templates/Pagination/rel_links.html.twig
@@ -1,9 +1,9 @@
 {% if pageCount > 1 %}
     {% if previous is defined %}
-        <link rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}" />
+        <link rel="prev" href="{{ path(route, knp_pagination_query(query, previous, options)) }}" />
     {% endif %}
 
     {% if next is defined %}
-        <link rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}" />
+        <link rel="next" href="{{ path(route, knp_pagination_query(query, next, options)) }}" />
     {% endif %}
 {% endif %}

--- a/templates/Pagination/semantic_ui_pagination.html.twig
+++ b/templates/Pagination/semantic_ui_pagination.html.twig
@@ -12,20 +12,20 @@
 #}
 <div class="ui pagination menu">
     {% if first is defined and current != first %}
-        <a class="icon item" href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">
+        <a class="icon item" href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">
             <i class="angle double left icon"></i>
         </a>
     {% endif %}
 
     {% if previous is defined %}
-        <a rel="prev" class="item icon" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">
+        <a rel="prev" class="item icon" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">
             <i class="angle left icon"></i>
         </a>
     {% endif %}
 
     {% for page in pagesInRange %}
         {% if page != current %}
-            <a class="item" href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
+            <a class="item" href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
         {% else %}
             <span class="active item">{{ page }}</span>
         {% endif %}
@@ -33,13 +33,13 @@
     {% endfor %}
 
     {% if next is defined %}
-        <a rel="next" class="icon item" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">
+        <a rel="next" class="icon item" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">
             <i class="angle right icon"></i>
         </a>
     {% endif %}
 
     {% if last is defined and current != last %}
-        <a class="icon item" href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">
+        <a class="icon item" href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">
             <i class="angle right double icon"></i>
         </a>
     {% endif %}

--- a/templates/Pagination/semantic_ui_pagination.html.twig
+++ b/templates/Pagination/semantic_ui_pagination.html.twig
@@ -12,20 +12,20 @@
 #}
 <div class="ui pagination menu">
     {% if first is defined and current != first %}
-        <a class="icon item" href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">
+        <a class="icon item" href="{{ path(route, knp_pagination_query(query, first, options)) }}">
             <i class="angle double left icon"></i>
         </a>
     {% endif %}
 
     {% if previous is defined %}
-        <a rel="prev" class="item icon" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">
+        <a rel="prev" class="item icon" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">
             <i class="angle left icon"></i>
         </a>
     {% endif %}
 
     {% for page in pagesInRange %}
         {% if page != current %}
-            <a class="item" href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
+            <a class="item" href="{{ path(route, knp_pagination_query(query, page, options)) }}">{{ page }}</a>
         {% else %}
             <span class="active item">{{ page }}</span>
         {% endif %}
@@ -33,13 +33,13 @@
     {% endfor %}
 
     {% if next is defined %}
-        <a rel="next" class="icon item" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">
+        <a rel="next" class="icon item" href="{{ path(route, knp_pagination_query(query, next, options)) }}">
             <i class="angle right icon"></i>
         </a>
     {% endif %}
 
     {% if last is defined and current != last %}
-        <a class="icon item" href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">
+        <a class="icon item" href="{{ path(route, knp_pagination_query(query, last, options)) }}">
             <i class="angle right double icon"></i>
         </a>
     {% endif %}

--- a/templates/Pagination/semantic_ui_pagination.html.twig
+++ b/templates/Pagination/semantic_ui_pagination.html.twig
@@ -12,20 +12,20 @@
 #}
 <div class="ui pagination menu">
     {% if first is defined and current != first %}
-        <a class="icon item" href="{{ path(route, knp_pagination_query(query, first)) }}">
+        <a class="icon item" href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">
             <i class="angle double left icon"></i>
         </a>
     {% endif %}
 
     {% if previous is defined %}
-        <a rel="prev" class="item icon" href="{{ path(route, knp_pagination_query(query, previous)) }}">
+        <a rel="prev" class="item icon" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">
             <i class="angle left icon"></i>
         </a>
     {% endif %}
 
     {% for page in pagesInRange %}
         {% if page != current %}
-            <a class="item" href="{{ path(route, knp_pagination_query(query, page)) }}">{{ page }}</a>
+            <a class="item" href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
         {% else %}
             <span class="active item">{{ page }}</span>
         {% endif %}
@@ -33,13 +33,13 @@
     {% endfor %}
 
     {% if next is defined %}
-        <a rel="next" class="icon item" href="{{ path(route, knp_pagination_query(query, next)) }}">
+        <a rel="next" class="icon item" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">
             <i class="angle right icon"></i>
         </a>
     {% endif %}
 
     {% if last is defined and current != last %}
-        <a class="icon item" href="{{ path(route, knp_pagination_query(query, last)) }}">
+        <a class="icon item" href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">
             <i class="angle right double icon"></i>
         </a>
     {% endif %}

--- a/templates/Pagination/sliding.html.twig
+++ b/templates/Pagination/sliding.html.twig
@@ -3,20 +3,20 @@
     <div class="pagination">
         {% if first is defined and current != first %}
             <span class="first">
-                <a href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">&lt;&lt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, first, options)) }}">&lt;&lt;</a>
             </span>
         {% endif %}
 
         {% if previous is defined %}
             <span class="previous">
-                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">&lt;</a>
+                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">&lt;</a>
             </span>
         {% endif %}
 
         {% for page in pagesInRange %}
             {% if page != current %}
                 <span class="page">
-                    <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, page, options)) }}">{{ page }}</a>
                 </span>
             {% else %}
                 <span class="current">{{ page }}</span>
@@ -25,13 +25,13 @@
 
         {% if next is defined %}
             <span class="next">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">&gt;</a>
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, options)) }}">&gt;</a>
             </span>
         {% endif %}
 
         {% if last is defined and current != last %}
             <span class="last">
-                <a href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">&gt;&gt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, last, options)) }}">&gt;&gt;</a>
             </span>
         {% endif %}
     </div>

--- a/templates/Pagination/sliding.html.twig
+++ b/templates/Pagination/sliding.html.twig
@@ -3,20 +3,20 @@
     <div class="pagination">
         {% if first is defined and current != first %}
             <span class="first">
-                <a href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">&lt;&lt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">&lt;&lt;</a>
             </span>
         {% endif %}
 
         {% if previous is defined %}
             <span class="previous">
-                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">&lt;</a>
+                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">&lt;</a>
             </span>
         {% endif %}
 
         {% for page in pagesInRange %}
             {% if page != current %}
                 <span class="page">
-                    <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
                 </span>
             {% else %}
                 <span class="current">{{ page }}</span>
@@ -25,13 +25,13 @@
 
         {% if next is defined %}
             <span class="next">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">&gt;</a>
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">&gt;</a>
             </span>
         {% endif %}
 
         {% if last is defined and current != last %}
             <span class="last">
-                <a href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">&gt;&gt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">&gt;&gt;</a>
             </span>
         {% endif %}
     </div>

--- a/templates/Pagination/sliding.html.twig
+++ b/templates/Pagination/sliding.html.twig
@@ -3,20 +3,20 @@
     <div class="pagination">
         {% if first is defined and current != first %}
             <span class="first">
-                <a href="{{ path(route, knp_pagination_query(query, first)) }}">&lt;&lt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">&lt;&lt;</a>
             </span>
         {% endif %}
 
         {% if previous is defined %}
             <span class="previous">
-                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous)) }}">&lt;</a>
+                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">&lt;</a>
             </span>
         {% endif %}
 
         {% for page in pagesInRange %}
             {% if page != current %}
                 <span class="page">
-                    <a href="{{ path(route, knp_pagination_query(query, page)) }}">{{ page }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
                 </span>
             {% else %}
                 <span class="current">{{ page }}</span>
@@ -25,13 +25,13 @@
 
         {% if next is defined %}
             <span class="next">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next)) }}">&gt;</a>
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">&gt;</a>
             </span>
         {% endif %}
 
         {% if last is defined and current != last %}
             <span class="last">
-                <a href="{{ path(route, knp_pagination_query(query, last)) }}">&gt;&gt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">&gt;&gt;</a>
             </span>
         {% endif %}
     </div>

--- a/templates/Pagination/tailwindcss_pagination.html.twig
+++ b/templates/Pagination/tailwindcss_pagination.html.twig
@@ -4,20 +4,20 @@
         <div class="flex items-baseline flex-row border border-gray-400 rounded-sm w-auto">
         {% if first is defined and current != first %}
             <span class="bg-white text-blue-600 px-3 py-2 text-lg border-r border-gray-400 font-bold">
-                <a href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">&lt;&lt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">&lt;&lt;</a>
             </span>
         {% endif %}
 
         {% if previous is defined %}
             <span class="bg-white text-blue-600 px-3 text-lg py-2 border-r border-gray-400">
-                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">&lt;</a>
+                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">&lt;</a>
             </span>
         {% endif %}
 
         {% for page in pagesInRange %}
             {% if page != current %}
                 <span class="bg-white text-blue-600 px-3 py-2 text-lg border-r  border-gray-400">
-                    <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
                 </span>
             {% else %}
                 <span class="bg-blue-600 text-white px-3 py-2 text-lg font-bold">{{ page }}</span>
@@ -26,13 +26,13 @@
 
         {% if next is defined %}
             <span class="bg-white text-blue-600 px-3 py-2 text-lg border-r border-gray-400">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">&gt;</a>
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">&gt;</a>
             </span>
         {% endif %}
 
         {% if last is defined and current != last %}
             <span class="bg-white text-blue-600 px-3 py-2 text-lg border-gray-400 font-bold">
-                <a href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">&gt;&gt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">&gt;&gt;</a>
             </span>
         {% endif %}
         </div>

--- a/templates/Pagination/tailwindcss_pagination.html.twig
+++ b/templates/Pagination/tailwindcss_pagination.html.twig
@@ -4,20 +4,20 @@
         <div class="flex items-baseline flex-row border border-gray-400 rounded-sm w-auto">
         {% if first is defined and current != first %}
             <span class="bg-white text-blue-600 px-3 py-2 text-lg border-r border-gray-400 font-bold">
-                <a href="{{ path(route, knp_pagination_query(query, first, paginatorOptions)) }}">&lt;&lt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, first, options)) }}">&lt;&lt;</a>
             </span>
         {% endif %}
 
         {% if previous is defined %}
             <span class="bg-white text-blue-600 px-3 text-lg py-2 border-r border-gray-400">
-                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">&lt;</a>
+                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">&lt;</a>
             </span>
         {% endif %}
 
         {% for page in pagesInRange %}
             {% if page != current %}
                 <span class="bg-white text-blue-600 px-3 py-2 text-lg border-r  border-gray-400">
-                    <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, page, options)) }}">{{ page }}</a>
                 </span>
             {% else %}
                 <span class="bg-blue-600 text-white px-3 py-2 text-lg font-bold">{{ page }}</span>
@@ -26,13 +26,13 @@
 
         {% if next is defined %}
             <span class="bg-white text-blue-600 px-3 py-2 text-lg border-r border-gray-400">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">&gt;</a>
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, options)) }}">&gt;</a>
             </span>
         {% endif %}
 
         {% if last is defined and current != last %}
             <span class="bg-white text-blue-600 px-3 py-2 text-lg border-gray-400 font-bold">
-                <a href="{{ path(route, knp_pagination_query(query, last, paginatorOptions)) }}">&gt;&gt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, last, options)) }}">&gt;&gt;</a>
             </span>
         {% endif %}
         </div>

--- a/templates/Pagination/tailwindcss_pagination.html.twig
+++ b/templates/Pagination/tailwindcss_pagination.html.twig
@@ -4,20 +4,20 @@
         <div class="flex items-baseline flex-row border border-gray-400 rounded-sm w-auto">
         {% if first is defined and current != first %}
             <span class="bg-white text-blue-600 px-3 py-2 text-lg border-r border-gray-400 font-bold">
-                <a href="{{ path(route, knp_pagination_query(query, first)) }}">&lt;&lt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, first, pagination)) }}">&lt;&lt;</a>
             </span>
         {% endif %}
 
         {% if previous is defined %}
             <span class="bg-white text-blue-600 px-3 text-lg py-2 border-r border-gray-400">
-                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous)) }}">&lt;</a>
+                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">&lt;</a>
             </span>
         {% endif %}
 
         {% for page in pagesInRange %}
             {% if page != current %}
                 <span class="bg-white text-blue-600 px-3 py-2 text-lg border-r  border-gray-400">
-                    <a href="{{ path(route, knp_pagination_query(query, page)) }}">{{ page }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
                 </span>
             {% else %}
                 <span class="bg-blue-600 text-white px-3 py-2 text-lg font-bold">{{ page }}</span>
@@ -26,13 +26,13 @@
 
         {% if next is defined %}
             <span class="bg-white text-blue-600 px-3 py-2 text-lg border-r border-gray-400">
-                <a rel="next" href="{{ path(route, knp_pagination_query(query, next)) }}">&gt;</a>
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">&gt;</a>
             </span>
         {% endif %}
 
         {% if last is defined and current != last %}
             <span class="bg-white text-blue-600 px-3 py-2 text-lg border-gray-400 font-bold">
-                <a href="{{ path(route, knp_pagination_query(query, last)) }}">&gt;&gt;</a>
+                <a href="{{ path(route, knp_pagination_query(query, last, pagination)) }}">&gt;&gt;</a>
             </span>
         {% endif %}
         </div>

--- a/templates/Pagination/twitter_bootstrap_v4_pagination.html.twig
+++ b/templates/Pagination/twitter_bootstrap_v4_pagination.html.twig
@@ -17,7 +17,7 @@
 
             {% if previous is defined %}
                 <li class="page-item">
-                    <a class="page-link" rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+                    <a class="page-link" rel="prev" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
                 </li>
             {% else %}
                 <li class="page-item disabled">
@@ -27,11 +27,11 @@
 
             {% if startPage > 1 %}
                 <li class="page-item">
-                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, 1, paginatorOptions)) }}">1</a>
+                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, 1, options)) }}">1</a>
                 </li>
                 {% if startPage == 3 %}
                     <li class="page-item">
-                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, 2, paginatorOptions)) }}">2</a>
+                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, 2, options)) }}">2</a>
                     </li>
                 {% elseif startPage != 2 %}
                     <li class="page-item disabled">
@@ -43,7 +43,7 @@
             {% for page in pagesInRange %}
                 {% if page != current %}
                     <li class="page-item">
-                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
+                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, page, options)) }}">{{ page }}</a>
                     </li>
                 {% else %}
                     <li class="page-item active">
@@ -61,18 +61,18 @@
                         </li>
                     {% else %}
                         <li class="page-item">
-                            <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount - 1, paginatorOptions)) }}">{{ pageCount - 1 }}</a>
+                            <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount - 1, options)) }}">{{ pageCount - 1 }}</a>
                         </li>
                     {% endif %}
                 {% endif %}
                 <li class="page-item">
-                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount, paginatorOptions)) }}">{{ pageCount }}</a>
+                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount, options)) }}">{{ pageCount }}</a>
                 </li>
             {% endif %}
 
             {% if next is defined %}
                 <li class="page-item">
-                    <a class="page-link" rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
+                    <a class="page-link" rel="next" href="{{ path(route, knp_pagination_query(query, next, options)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
                 </li>
             {% else %}
                 <li  class="page-item disabled">

--- a/templates/Pagination/twitter_bootstrap_v4_pagination.html.twig
+++ b/templates/Pagination/twitter_bootstrap_v4_pagination.html.twig
@@ -17,7 +17,7 @@
 
             {% if previous is defined %}
                 <li class="page-item">
-                    <a class="page-link" rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+                    <a class="page-link" rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
                 </li>
             {% else %}
                 <li class="page-item disabled">
@@ -27,11 +27,11 @@
 
             {% if startPage > 1 %}
                 <li class="page-item">
-                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, 1, pagination)) }}">1</a>
+                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, 1, paginatorOptions)) }}">1</a>
                 </li>
                 {% if startPage == 3 %}
                     <li class="page-item">
-                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, 2, pagination)) }}">2</a>
+                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, 2, paginatorOptions)) }}">2</a>
                     </li>
                 {% elseif startPage != 2 %}
                     <li class="page-item disabled">
@@ -43,7 +43,7 @@
             {% for page in pagesInRange %}
                 {% if page != current %}
                     <li class="page-item">
-                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
+                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
                     </li>
                 {% else %}
                     <li class="page-item active">
@@ -61,18 +61,18 @@
                         </li>
                     {% else %}
                         <li class="page-item">
-                            <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount - 1, pagination)) }}">{{ pageCount - 1 }}</a>
+                            <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount - 1, paginatorOptions)) }}">{{ pageCount - 1 }}</a>
                         </li>
                     {% endif %}
                 {% endif %}
                 <li class="page-item">
-                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount, pagination)) }}">{{ pageCount }}</a>
+                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount, paginatorOptions)) }}">{{ pageCount }}</a>
                 </li>
             {% endif %}
 
             {% if next is defined %}
                 <li class="page-item">
-                    <a class="page-link" rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
+                    <a class="page-link" rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
                 </li>
             {% else %}
                 <li  class="page-item disabled">

--- a/templates/Pagination/twitter_bootstrap_v4_pagination.html.twig
+++ b/templates/Pagination/twitter_bootstrap_v4_pagination.html.twig
@@ -17,7 +17,7 @@
 
             {% if previous is defined %}
                 <li class="page-item">
-                    <a class="page-link" rel="prev" href="{{ path(route, knp_pagination_query(query, previous)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+                    <a class="page-link" rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
                 </li>
             {% else %}
                 <li class="page-item disabled">
@@ -27,11 +27,11 @@
 
             {% if startPage > 1 %}
                 <li class="page-item">
-                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, 1)) }}">1</a>
+                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, 1, pagination)) }}">1</a>
                 </li>
                 {% if startPage == 3 %}
                     <li class="page-item">
-                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, 2)) }}">2</a>
+                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, 2, pagination)) }}">2</a>
                     </li>
                 {% elseif startPage != 2 %}
                     <li class="page-item disabled">
@@ -43,7 +43,7 @@
             {% for page in pagesInRange %}
                 {% if page != current %}
                     <li class="page-item">
-                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, page)) }}">{{ page }}</a>
+                        <a class="page-link" href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
                     </li>
                 {% else %}
                     <li class="page-item active">
@@ -61,18 +61,18 @@
                         </li>
                     {% else %}
                         <li class="page-item">
-                            <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount - 1)) }}">{{ pageCount - 1 }}</a>
+                            <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount - 1, pagination)) }}">{{ pageCount - 1 }}</a>
                         </li>
                     {% endif %}
                 {% endif %}
                 <li class="page-item">
-                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount)) }}">{{ pageCount }}</a>
+                    <a class="page-link" href="{{ path(route, knp_pagination_query(query, pageCount, pagination)) }}">{{ pageCount }}</a>
                 </li>
             {% endif %}
 
             {% if next is defined %}
                 <li class="page-item">
-                    <a class="page-link" rel="next" href="{{ path(route, knp_pagination_query(query, next)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
+                    <a class="page-link" rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
                 </li>
             {% else %}
                 <li  class="page-item disabled">

--- a/templates/Pagination/uikit_v3_pagination.html.twig
+++ b/templates/Pagination/uikit_v3_pagination.html.twig
@@ -16,7 +16,7 @@
 
             {% if previous is defined %}
                 <li>
-                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
                 </li>
             {% else %}
                 <li class="uk-disabled">
@@ -26,11 +26,11 @@
 
             {% if startPage > 1 %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, 1, paginatorOptions)) }}">1</a>
+                    <a href="{{ path(route, knp_pagination_query(query, 1, options)) }}">1</a>
                 </li>
                 {% if startPage == 3 %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, 2, paginatorOptions)) }}">2</a>
+                        <a href="{{ path(route, knp_pagination_query(query, 2, options)) }}">2</a>
                     </li>
                 {% elseif startPage != 2 %}
                     <li class="uk-disabled">
@@ -42,7 +42,7 @@
             {% for page in pagesInRange %}
                 {% if page != current %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
+                        <a href="{{ path(route, knp_pagination_query(query, page, options)) }}">{{ page }}</a>
                     </li>
                 {% else %}
                     <li class="uk-active">
@@ -60,18 +60,18 @@
                         </li>
                     {% else %}
                         <li>
-                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), paginatorOptions)) }}">{{ pageCount - 1 }}</a>
+                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), options)) }}">{{ pageCount - 1 }}</a>
                         </li>
                     {% endif %}
                 {% endif %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, pageCount, paginatorOptions)) }}">{{ pageCount }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, pageCount, options)) }}">{{ pageCount }}</a>
                 </li>
             {% endif %}
 
             {% if next is defined %}
                 <li>
-                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
+                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next, options)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
                 </li>
             {% else %}
                 <li class="uk-disabled">

--- a/templates/Pagination/uikit_v3_pagination.html.twig
+++ b/templates/Pagination/uikit_v3_pagination.html.twig
@@ -16,7 +16,7 @@
 
             {% if previous is defined %}
                 <li>
-                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, paginatorOptions)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
                 </li>
             {% else %}
                 <li class="uk-disabled">
@@ -26,11 +26,11 @@
 
             {% if startPage > 1 %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, 1, pagination)) }}">1</a>
+                    <a href="{{ path(route, knp_pagination_query(query, 1, paginatorOptions)) }}">1</a>
                 </li>
                 {% if startPage == 3 %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, 2, pagination)) }}">2</a>
+                        <a href="{{ path(route, knp_pagination_query(query, 2, paginatorOptions)) }}">2</a>
                     </li>
                 {% elseif startPage != 2 %}
                     <li class="uk-disabled">
@@ -42,7 +42,7 @@
             {% for page in pagesInRange %}
                 {% if page != current %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
+                        <a href="{{ path(route, knp_pagination_query(query, page, paginatorOptions)) }}">{{ page }}</a>
                     </li>
                 {% else %}
                     <li class="uk-active">
@@ -60,18 +60,18 @@
                         </li>
                     {% else %}
                         <li>
-                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), pagination)) }}">{{ pageCount - 1 }}</a>
+                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), paginatorOptions)) }}">{{ pageCount - 1 }}</a>
                         </li>
                     {% endif %}
                 {% endif %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, pageCount, pagination)) }}">{{ pageCount }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, pageCount, paginatorOptions)) }}">{{ pageCount }}</a>
                 </li>
             {% endif %}
 
             {% if next is defined %}
                 <li>
-                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
+                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next, paginatorOptions)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
                 </li>
             {% else %}
                 <li class="uk-disabled">

--- a/templates/Pagination/uikit_v3_pagination.html.twig
+++ b/templates/Pagination/uikit_v3_pagination.html.twig
@@ -16,7 +16,7 @@
 
             {% if previous is defined %}
                 <li>
-                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, pagination)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
                 </li>
             {% else %}
                 <li class="uk-disabled">
@@ -26,11 +26,11 @@
 
             {% if startPage > 1 %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, 1)) }}">1</a>
+                    <a href="{{ path(route, knp_pagination_query(query, 1, pagination)) }}">1</a>
                 </li>
                 {% if startPage == 3 %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, 2)) }}">2</a>
+                        <a href="{{ path(route, knp_pagination_query(query, 2, pagination)) }}">2</a>
                     </li>
                 {% elseif startPage != 2 %}
                     <li class="uk-disabled">
@@ -42,7 +42,7 @@
             {% for page in pagesInRange %}
                 {% if page != current %}
                     <li>
-                        <a href="{{ path(route, knp_pagination_query(query, page)) }}">{{ page }}</a>
+                        <a href="{{ path(route, knp_pagination_query(query, page, pagination)) }}">{{ page }}</a>
                     </li>
                 {% else %}
                     <li class="uk-active">
@@ -60,18 +60,18 @@
                         </li>
                     {% else %}
                         <li>
-                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1))) }}">{{ pageCount - 1 }}</a>
+                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), pagination)) }}">{{ pageCount - 1 }}</a>
                         </li>
                     {% endif %}
                 {% endif %}
                 <li>
-                    <a href="{{ path(route, knp_pagination_query(query, pageCount)) }}">{{ pageCount }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, pageCount, pagination)) }}">{{ pageCount }}</a>
                 </li>
             {% endif %}
 
             {% if next is defined %}
                 <li>
-                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
+                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next, pagination)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
                 </li>
             {% else %}
                 <li class="uk-disabled">


### PR DESCRIPTION
This PR resolves #815 in the manner suggested by @garak in that issue - passing the entire SlidingPagination object to the templates to allow the pageParameterName to be accessed.

In the future it would likely be possible to remove some of the local variables which are created as the template is being rendered since they could be accessed directly from the SlidingPagination, however I wanted to keep this PR to solving just the issue at hand.