### PR TITLE
Provide default for $options variable

### DIFF
--- a/src/Twig/Extension/PaginationRuntime.php
+++ b/src/Twig/Extension/PaginationRuntime.php
@@ -114,7 +114,7 @@ final class PaginationRuntime implements RuntimeExtensionInterface
      * @param array<string, mixed>      $options
      * @return array<string, mixed>
      */
-    public function getQueryParams(array $query, int $page, array $options): array
+    public function getQueryParams(array $query, int $page, array $options = []): array
     {
         $pageName = $this->pageName;
         if (isset($options['pageParameterName']) && is_string($options['pageParameterName'])) {


### PR DESCRIPTION
As requested in the [final comment](https://github.com/KnpLabs/KnpPaginatorBundle/pull/820#pullrequestreview-2650434102) of PR #820 this PR provides a default value for the $options variable to address. Since #820 had already been merged it seemed the best way forward was this new PR so we can get a release which addresses #815. Hope this is what you expected @garak.