### PR TITLE
[Improvement] Indentation fix & lines breaks harmonization/standardization

### DIFF
--- a/templates/Pagination/foundation_v6_pagination.html.twig
+++ b/templates/Pagination/foundation_v6_pagination.html.twig
@@ -2,7 +2,6 @@
     <nav aria-label="Pagination">
         {% set classAlign = (align is defined) ? " text-#{align}" : '' %}
         <ul class="pagination{{ classAlign }}">
-
             {% if previous is defined %}
                 <li class="pagination-previous">
                     <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">
@@ -68,7 +67,6 @@
                     {{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}
                 </li>
             {% endif %}
-
         </ul>
     </nav>
 {% endif %}

--- a/templates/Pagination/uikit_v3_pagination.html.twig
+++ b/templates/Pagination/uikit_v3_pagination.html.twig
@@ -13,70 +13,69 @@
 #}
 {% if pageCount > 1 %}
     <ul class="uk-pagination uk-flex-center uk-margin-medium-top">
+        {% if previous is defined %}
+            <li>
+                <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+            </li>
+        {% else %}
+            <li class="uk-disabled">
+                <span>&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</span>
+            </li>
+        {% endif %}
 
-            {% if previous is defined %}
+        {% if startPage > 1 %}
+            <li>
+                <a href="{{ path(route, knp_pagination_query(query, 1, options)) }}">1</a>
+            </li>
+            {% if startPage == 3 %}
                 <li>
-                    <a rel="prev" href="{{ path(route, knp_pagination_query(query, previous, options)) }}">&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</a>
+                    <a href="{{ path(route, knp_pagination_query(query, 2, options)) }}">2</a>
+                </li>
+            {% elseif startPage != 2 %}
+                <li class="uk-disabled">
+                    <span>&hellip;</span>
+                </li>
+            {% endif %}
+        {% endif %}
+
+        {% for page in pagesInRange %}
+            {% if page != current %}
+                <li>
+                    <a href="{{ path(route, knp_pagination_query(query, page, options)) }}">{{ page }}</a>
                 </li>
             {% else %}
-                <li class="uk-disabled">
-                    <span>&laquo;&nbsp;{{ 'label_previous'|trans({}, 'KnpPaginatorBundle') }}</span>
+                <li class="uk-active">
+                    <span>{{ page }}</span>
                 </li>
             {% endif %}
 
-            {% if startPage > 1 %}
-                <li>
-                    <a href="{{ path(route, knp_pagination_query(query, 1, options)) }}">1</a>
-                </li>
-                {% if startPage == 3 %}
-                    <li>
-                        <a href="{{ path(route, knp_pagination_query(query, 2, options)) }}">2</a>
-                    </li>
-                {% elseif startPage != 2 %}
+        {% endfor %}
+
+        {% if pageCount > endPage %}
+            {% if pageCount > (endPage + 1) %}
+                {% if pageCount > (endPage + 2) %}
                     <li class="uk-disabled">
                         <span>&hellip;</span>
                     </li>
-                {% endif %}
-            {% endif %}
-
-            {% for page in pagesInRange %}
-                {% if page != current %}
-                    <li>
-                        <a href="{{ path(route, knp_pagination_query(query, page, options)) }}">{{ page }}</a>
-                    </li>
                 {% else %}
-                    <li class="uk-active">
-                        <span>{{ page }}</span>
+                    <li>
+                        <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), options)) }}">{{ pageCount - 1 }}</a>
                     </li>
                 {% endif %}
-
-            {% endfor %}
-
-            {% if pageCount > endPage %}
-                {% if pageCount > (endPage + 1) %}
-                    {% if pageCount > (endPage + 2) %}
-                        <li class="uk-disabled">
-                            <span>&hellip;</span>
-                        </li>
-                    {% else %}
-                        <li>
-                            <a href="{{ path(route, knp_pagination_query(query, (pageCount - 1), options)) }}">{{ pageCount - 1 }}</a>
-                        </li>
-                    {% endif %}
-                {% endif %}
-                <li>
-                    <a href="{{ path(route, knp_pagination_query(query, pageCount, options)) }}">{{ pageCount }}</a>
-                </li>
             {% endif %}
+            <li>
+                <a href="{{ path(route, knp_pagination_query(query, pageCount, options)) }}">{{ pageCount }}</a>
+            </li>
+        {% endif %}
 
-            {% if next is defined %}
-                <li>
-                    <a rel="next" href="{{ path(route, knp_pagination_query(query, next, options)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
-                </li>
-            {% else %}
-                <li class="uk-disabled">
-                    <span>{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</span>
-                </li>
-            {% endif %}
-        </ul>
+        {% if next is defined %}
+            <li>
+                <a rel="next" href="{{ path(route, knp_pagination_query(query, next, options)) }}">{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
+            </li>
+        {% else %}
+            <li class="uk-disabled">
+                <span>{{ 'label_next'|trans({}, 'KnpPaginatorBundle') }}&nbsp;&raquo;</span>
+            </li>
+        {% endif %}
+    </ul>
 {% endif %}

--- a/templates/Pagination/uikit_v3_sortable.html.twig
+++ b/templates/Pagination/uikit_v3_sortable.html.twig
@@ -18,5 +18,5 @@
             <i></i>
         {% endif %}
     </span>
-{{- title -}}
+    {{- title -}}
 </a>


### PR DESCRIPTION
Fix indentation in files :
* ``templates/Pagination/uikit_v3_pagination.html.twig``
* ``templates/Pagination/uikit_v3_sortable.html.twig``

Harmonization or line breaks according other templates in files :
* ``templates/Pagination/foundation_v6_pagination.html.twig``
* ``templates/Pagination/uikit_v3_pagination.html.twig``