### PR TITLE
fix cs check in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,8 @@ jobs:
               uses: actions/checkout@v4
             - name: Run PHP-CS-Fixer
               uses: docker://oskarstark/php-cs-fixer-ga
+              with:
+                args: --diff --dry-run
 
     twig-cs-fixer:
         runs-on: ubuntu-24.04

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.11",
-        "phpunit/phpunit": "^10.5 || ^11.3",
+        "phpstan/phpstan": "^1.12",
+        "phpunit/phpunit": "^10.5 || ^11.5 || ^12.0",
         "symfony/expression-language": "^6.4 || ^7.0",
         "symfony/templating": "^6.4 || ^7.0"
     },

--- a/src/Twig/Extension/PaginationExtension.php
+++ b/src/Twig/Extension/PaginationExtension.php
@@ -3,7 +3,6 @@
 namespace Knp\Bundle\PaginatorBundle\Twig\Extension;
 
 use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 final class PaginationExtension extends AbstractExtension

--- a/src/Twig/Extension/PaginationRuntime.php
+++ b/src/Twig/Extension/PaginationRuntime.php
@@ -109,19 +109,19 @@ final class PaginationRuntime implements RuntimeExtensionInterface
     }
 
     /**
-     * @param array<string, mixed>      $query
-     * @param int                       $page
-     * @param array<string, mixed>      $options
+     * @param array<string, mixed> $query
+     * @param array<string, mixed> $options
+     *
      * @return array<string, mixed>
      */
     public function getQueryParams(array $query, int $page, array $options = []): array
     {
         $pageName = $this->pageName;
-        if (isset($options['pageParameterName']) && is_string($options['pageParameterName'])) {
+        if (isset($options['pageParameterName']) && \is_string($options['pageParameterName'])) {
             $pageName = $options['pageParameterName'];
         }
 
-        if ($page === 1 && $this->skipFirstPageLink) {
+        if (1 === $page && $this->skipFirstPageLink) {
             if (isset($query[$pageName])) {
                 unset($query[$pageName]);
             }
@@ -129,6 +129,6 @@ final class PaginationRuntime implements RuntimeExtensionInterface
             return $query;
         }
 
-        return array_merge($query, [$pageName => $page]);
+        return \array_merge($query, [$pageName => $page]);
     }
 }


### PR DESCRIPTION
Our current build of php-cs-fixer in CI fixes the source code instead of checking it: if a file has a wrong coding style, it is changed. That's useless, since the file is only changed in the build instance, and mainly it doesn't exit with a failing code.

I also added the latest version of PHPUnit