### PR TITLE
Make sort field and direction parameter names available as kernel parameters

### DIFF
--- a/src/DependencyInjection/KnpPaginatorExtension.php
+++ b/src/DependencyInjection/KnpPaginatorExtension.php
@@ -43,12 +43,14 @@ final class KnpPaginatorExtension extends Extension
         $container->setParameter('knp_paginator.page_limit', $config['page_limit']);
         $container->setParameter('knp_paginator.page_name', $config['default_options']['page_name']);
         $container->setParameter('knp_paginator.remove_first_page_param', $config['remove_first_page_param']);
+        $container->setParameter('knp_paginator.default.sort_field_name', $config['default_options']['sort_field_name']);
+        $container->setParameter('knp_paginator.default.sort_direction_name', $config['default_options']['sort_direction_name']);
 
         $paginatorDef = $container->getDefinition('knp_paginator');
         $paginatorDef->addMethodCall('setDefaultPaginatorOptions', [[
             'pageParameterName' => $config['default_options']['page_name'],
-            'sortFieldParameterName' => $config['default_options']['sort_field_name'],
-            'sortDirectionParameterName' => $config['default_options']['sort_direction_name'],
+            'sortFieldParameterName' => '%knp_paginator.default.sort_field_name%',
+            'sortDirectionParameterName' => '%knp_paginator.default.sort_direction_name%',
             'filterFieldParameterName' => $config['default_options']['filter_field_name'],
             'filterValueParameterName' => $config['default_options']['filter_value_name'],
             'distinct' => $config['default_options']['distinct'],


### PR DESCRIPTION
I have repeatedly come across the use case where I need to display a "filter" form above a list that is paginated.

It would be nice if the user could re-sort the list, then afterwards change the filter criteria and submit the filter form again while retaining the sort criteria.

To make that possible, the filter form needs to be aware of the current sort field and direction. In other words, it needs to include hidden form fields for those two query parameters.

It would be much easier to implement this in a generic fashion (with a Symfony `FormTypeExentsion`) if the parameter names for the sort field and direction were available in the kernel as parameters.

This does not yet solve the special case of having "local" (non-default) parameter names, at least that would require extra configuration for the Symfony `FormType`. But for "default" lists, the `FormTypeExtension` could work out-of-the-box.