### PR TITLE
Allow symfony/config ^8.0 to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "knplabs/knp-components": "^4.4 || ^5.0",
-        "symfony/config": "^6.4 || ^7.0",
+        "symfony/config": "^6.4 || ^7.0 || ^8.0",
         "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
         "symfony/event-dispatcher": "^6.4 || ^7.0 || ^8.0",
         "symfony/http-foundation": "^6.4 || ^7.0 || ^8.0",


### PR DESCRIPTION
I guess this was missed accidentally in #844.