### PR TITLE
Narrow exception listener handling

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -7,14 +7,14 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
- * Intercept OutOfRangeException/UnexpectedValueException and throw http-related exceptions instead.
+ * Intercept invalid paginator values and throw http-related exceptions instead.
  */
 final class ExceptionListener
 {
     public function onKernelException(ExceptionEvent $event): void
     {
         $exception = $event->getThrowable();
-        if ($exception instanceof \OutOfRangeException || $exception instanceof InvalidValueException) {
+        if ($exception instanceof InvalidValueException) {
             $event->setThrowable(new NotFoundHttpException('Not Found.', $exception));
         }
     }

--- a/tests/EventListener/ExceptionListenerTest.php
+++ b/tests/EventListener/ExceptionListenerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Knp\Bundle\PaginatorBundle\Tests\EventListener;
+
+use Knp\Bundle\PaginatorBundle\EventListener\ExceptionListener;
+use Knp\Component\Pager\Exception\InvalidValueException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class ExceptionListenerTest extends TestCase
+{
+    public function testLeavesNativeOutOfRangeExceptionUntouched(): void
+    {
+        $exception = new \OutOfRangeException();
+        $event = $this->createEvent($exception);
+
+        (new ExceptionListener())->onKernelException($event);
+
+        self::assertSame($exception, $event->getThrowable());
+    }
+
+    public function testConvertsInvalidPaginatorValueToNotFoundException(): void
+    {
+        $exception = new InvalidValueException();
+        $event = $this->createEvent($exception);
+
+        (new ExceptionListener())->onKernelException($event);
+
+        self::assertInstanceOf(NotFoundHttpException::class, $event->getThrowable());
+        self::assertSame($exception, $event->getThrowable()->getPrevious());
+    }
+
+    private function createEvent(\Throwable $exception): ExceptionEvent
+    {
+        return new ExceptionEvent(
+            $this->createStub(HttpKernelInterface::class),
+            new Request(),
+            HttpKernelInterface::MAIN_REQUEST,
+            $exception,
+        );
+    }
+}


### PR DESCRIPTION
### Improvement

|    Q        |   A
|------------ | ------
| New Feature | no
| RFC         | no
| BC Break    | yes

#### Summary

Limit the exception listener to paginator `InvalidValueException` instances so unrelated native `OutOfRangeException` errors retain their original handling.

Fix #854

## Test verification (RED → GREEN)

Upstream `master` with only the regression test:

```text
FAILURES!
Tests: 2, Assertions: 3, Failures: 1.
Failed asserting that two variables reference the same object.
```

Patched branch:

```text
OK (2 tests, 3 assertions)
```

Full PHPUnit suite:

```text
OK, but there were issues!
Tests: 22, Assertions: 31, PHPUnit Notices: 1.
```

Changed executable lines have 100% coverage (3/3 listener statements covered).
