### PR TITLE
Add PHPUnit 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^10.5 || ^11.5 || ^12.2",
+        "phpunit/phpunit": "^10.5 || ^11.5 || ^12.2 || ^13.0",
         "symfony/templating": "^6.4 || ^7.0 || ^8.0",
         "symfony/translation": "^6.4 || ^7.0 || ^8.0",
         "twig/twig": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^10.5 || ^11.5 || ^12.2 || ^13.0",
+        "phpunit/phpunit": "^10.5 || ^11.5 || ^12.5 || ^13.2",
         "symfony/templating": "^6.4 || ^7.0 || ^8.0",
         "symfony/translation": "^6.4 || ^7.0 || ^8.0",
         "twig/twig": "^3.0"

--- a/tests/SlidingPaginationSubscriberTest.php
+++ b/tests/SlidingPaginationSubscriberTest.php
@@ -135,7 +135,7 @@ final class SlidingPaginationSubscriberTest extends TestCase
         $paginationEvent = new Event\PaginationEvent();
         $paginationEvent->options = &$this->options;
 
-        $kernel = $this->createMock(HttpKernelInterface::class);
+        $kernel = $this->createStub(HttpKernelInterface::class);
         $request = new Request($query, [], $attributes);
         $requestEvent = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
 


### PR DESCRIPTION
### New Feature

No.

### RFC

No.

### BC Break

No.

### Summary

Adds PHPUnit 13 support while keeping the existing PHP and PHPUnit support ranges unchanged.

The existing PHPUnit notice in `SlidingPaginationSubscriberTest` was also fixed by replacing a mock without expectations with a stub.

This is intentionally limited to the PHPUnit 13 part discussed in #856.

### Tests

- `composer validate --strict`
- `composer test` with PHP 8.5.9 / PHPUnit 13.3.1: 22 tests, 31 assertions
- `vendor/bin/phpstan analyse`
- `git diff --check`